### PR TITLE
Custom writer identities

### DIFF
--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -2,6 +2,10 @@ provider "google" {
   project = var.project_id
 }
 
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
 #1. Enable required services in GCP
 resource "google_project_service" "enable_pubsub_service" {
   project = var.project_id
@@ -70,14 +74,13 @@ resource "google_logging_project_sink" "masthead_sink" {
   destination = "pubsub.googleapis.com/projects/${var.project_id}/topics/masthead-topic"
   filter      = "protoPayload.methodName=\"google.cloud.bigquery.storage.v1.BigQueryWrite.AppendRows\" OR \"google.cloud.bigquery.v2.JobService.InsertJob\" OR \"google.cloud.bigquery.v2.TableService.InsertTable\" OR \"google.cloud.bigquery.v2.JobService.Query\" resource.type =\"bigquery_table\" OR resource.type =\"bigquery_dataset\" OR resource.type =\"bigquery_project\""
   project     = var.project_id
-  unique_writer_identity = false
 }
 
 #4. Grant Cloud Logs default Service Account PubSub Publisher role.
 resource "google_project_iam_member" "grant-cloud-logs-publisher-role" {
   project = var.project_id
   role    = "roles/pubsub.publisher"
-  member  = "serviceAccount:cloud-logs@system.gserviceaccount.com"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-logging.iam.gserviceaccount.com"
 }
 
 #5. Grant Masthead service account required roles: BigQuery Metadata Viewer, BigQuery Resource Viewer, PubSub Subscriber.

--- a/modules/dataform/main.tf
+++ b/modules/dataform/main.tf
@@ -2,6 +2,10 @@ provider "google" {
   project = var.project_id
 }
 
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
 #1. Enable required services in GCP
 resource "google_project_service" "enable_pubsub_service" {
   project = var.project_id
@@ -79,12 +83,11 @@ resource "google_logging_project_sink" "masthead_dataplex_sink" {
   filter      = "protoPayload.serviceName=\"dataform.googleapis.com\" OR resource.type=\"dataform.googleapis.com/Repository\""
   name        = "masthead-dataform-sink"
   project     = var.project_id
-  unique_writer_identity = false
 }
 
 #5. Grant cloud-logs SA PubSub Publisher role.
 resource "google_project_iam_member" "grant-cloud-logs-publisher-role" {
   project = var.project_id
   role    = "roles/pubsub.publisher"
-  member  = "serviceAccount:cloud-logs@system.gserviceaccount.com"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-logging.iam.gserviceaccount.com"
 }


### PR DESCRIPTION
Fixes service account reference for logging sinks.

Replaces hardcoded cloud-logs service account with dynamically generated service account using project number to ensure proper permissions for logging sinks across different GCP projects.

Removes unique_writer_identity parameter from logging sinks as it's no longer needed with the corrected service account format.

For the project number gets a project resource details by project_id.