### PR TITLE
Private logs permission removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.2.1] - 2025-06-18
+
+### Removed
+
+- **Deprecated Modules**: Removed `roles/logging.privateLogViewer` permissions for Masthead service account.
+
 ## [0.2.0] - 2025-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.2.1] - 2025-06-18
+## [0.2.1] - 2025-07-01
 
 ### Removed
 
-- **Deprecated Modules**: Removed `roles/logging.privateLogViewer` permissions for Masthead service account.
+- Removed `roles/logging.privateLogViewer` permissions for Masthead service account.
 
 ## [0.2.0] - 2025-06-11
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ terraform apply tfplan
 terraform init
 terraform plan -out=tfplan \
   -var="project_id=YOUR_PROJECT_ID" \
-  -var='enable_modules={"bigquery"=true,"dataform"=true,"dataplex"=true,"analytics_hub"=true}'
+  -var='enable_modules={"bigquery"=true,"dataform"=false,"dataplex"=false,"analytics_hub"=false}'
 terraform apply tfplan
 ```
 
@@ -113,7 +113,6 @@ masthead_service_accounts = {
   bigquery_sa  = string  # BigQuery monitoring service account
   dataform_sa  = string  # Dataform monitoring service account
   dataplex_sa  = string  # Dataplex monitoring service account
-  retro_sa     = string  # Retro analysis service account
 }
 ```
 

--- a/modules/analytics-hub/variables.tf
+++ b/modules/analytics-hub/variables.tf
@@ -8,7 +8,6 @@ variable "masthead_service_accounts" {
     bigquery_sa = string
     dataform_sa = string
     dataplex_sa = string
-    retro_sa    = string
   })
   description = "Masthead service account emails for different services"
 }

--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -107,10 +107,3 @@ resource "google_project_iam_member" "masthead_bigquery_permissions" {
   role    = each.value
   member  = "serviceAccount:${var.masthead_service_accounts.bigquery_sa}"
 }
-
-# Grant Masthead retro service account logging permissions
-resource "google_project_iam_member" "masthead_retro_logging_permissions" {
-  project = var.project_id
-  role    = "roles/logging.privateLogViewer"
-  member  = "serviceAccount:${var.masthead_service_accounts.retro_sa}"
-}

--- a/modules/bigquery/variables.tf
+++ b/modules/bigquery/variables.tf
@@ -8,7 +8,6 @@ variable "masthead_service_accounts" {
     bigquery_sa = string
     dataform_sa = string
     dataplex_sa = string
-    retro_sa    = string
   })
   description = "Masthead service account emails for different services"
 }

--- a/modules/dataform/variables.tf
+++ b/modules/dataform/variables.tf
@@ -8,7 +8,6 @@ variable "masthead_service_accounts" {
     bigquery_sa = string
     dataform_sa = string
     dataplex_sa = string
-    retro_sa    = string
   })
   description = "Masthead service account emails for different services"
 }

--- a/modules/dataplex/variables.tf
+++ b/modules/dataplex/variables.tf
@@ -8,7 +8,6 @@ variable "masthead_service_accounts" {
     bigquery_sa = string
     dataform_sa = string
     dataplex_sa = string
-    retro_sa    = string
   })
   description = "Masthead service account emails for different services"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,14 +13,12 @@ variable "masthead_service_accounts" {
     bigquery_sa = string
     dataform_sa = string
     dataplex_sa = string
-    retro_sa    = string
   })
   description = "Masthead service account emails for different services"
   default = {
     bigquery_sa = "masthead-data@masthead-prod.iam.gserviceaccount.com"
     dataform_sa = "masthead-dataform@masthead-prod.iam.gserviceaccount.com"
     dataplex_sa = "masthead-dataplex@masthead-prod.iam.gserviceaccount.com"
-    retro_sa    = "retro-data@masthead-prod.iam.gserviceaccount.com"
   }
 }
 


### PR DESCRIPTION
This pull request includes changes to remove deprecated modules and permissions related to the `retro_sa` service account across multiple files, as well as updates to the Terraform configuration to disable certain modules by default. These changes streamline the configuration and eliminate unused resources.

Closes #6

### Removal of deprecated modules and permissions:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR22-R27): Documented the removal of `roles/logging.privateLogViewer` permissions for the Masthead service account.
* [`modules/bigquery/main.tf`](diffhunk://#diff-d16038beb19cf52a2a648d952b55029db489aec5994ee1dd32a9be29e792e54aL110-L116): Removed the `google_project_iam_member` resource granting `roles/logging.privateLogViewer` permissions to the `retro_sa` service account.
* `variables.tf`, `modules/bigquery/variables.tf`, `modules/dataform/variables.tf`, `modules/dataplex/variables.tf`: Removed `retro_sa` from the `masthead_service_accounts` variable definition and its default values. [[1](diffhunk://#diff-9a663d19257e87e0603f62338351e6fbe525752162eeccb0d634063523cf98a5L11)] [2](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL16-L23)