### PR TITLE
Remove custom IAM role for Dataplex locations access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.2.5] - 2025-08-26
+
+### Removed
+
+- **Custom IAM Role**: Removed custom role for Dataplex locations access
+
 ## [0.2.4] - 2025-07-23
 
 ### Added
@@ -112,7 +118,8 @@ module "masthead_agent" {
 - Dataform integration
 - Dataplex monitoring
 
-[Unreleased]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.2.5...HEAD
+[0.2.5]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.2.1...v0.2.2

--- a/modules/dataplex/README.md
+++ b/modules/dataplex/README.md
@@ -7,5 +7,4 @@ This module sets up the necessary infrastructure for Masthead Data to monitor Da
 - **Pub/Sub Topic**: Receives Dataplex audit logs
 - **Pub/Sub Subscription**: Allows Masthead agents to consume audit logs
 - **Cloud Logging Sink**: Routes Dataplex audit logs to Pub/Sub
-- **Custom IAM Role**: Custom role for Dataplex locations access
 - **IAM Bindings**: Grants necessary permissions to Masthead service accounts

--- a/modules/dataplex/main.tf
+++ b/modules/dataplex/main.tf
@@ -3,10 +3,9 @@
 
 locals {
   resource_names = {
-    topic          = "masthead-dataplex-topic"
-    subscription   = "masthead-dataplex-subscription"
-    sink           = "masthead-dataplex-sink"
-    custom_role_id = "masthead_dataplex_locations"
+    topic        = "masthead-dataplex-topic"
+    subscription = "masthead-dataplex-subscription"
+    sink         = "masthead-dataplex-sink"
   }
 
   # Merge default labels with user-provided labels
@@ -99,22 +98,6 @@ resource "google_pubsub_subscription_iam_member" "masthead_subscription_subscrib
   member       = "serviceAccount:${var.masthead_service_accounts.dataplex_sa}"
 }
 
-# Create custom IAM role for Dataplex locations access
-resource "google_project_iam_custom_role" "masthead_dataplex_locations" {
-  depends_on = [google_project_service.required_apis]
-
-  project     = var.project_id
-  role_id     = local.resource_names.custom_role_id
-  title       = "Dataplex Locations (Masthead Data)"
-  description = "Custom role for Dataplex locations reader access for Masthead Data"
-  stage       = "GA"
-
-  permissions = [
-    "dataplex.locations.get",
-    "dataplex.locations.list"
-  ]
-}
-
 # Grant Masthead service account required Dataplex roles
 resource "google_project_iam_member" "masthead_dataplex_roles" {
   for_each = toset([
@@ -125,12 +108,5 @@ resource "google_project_iam_member" "masthead_dataplex_roles" {
 
   project = var.project_id
   role    = each.value
-  member  = "serviceAccount:${var.masthead_service_accounts.dataplex_sa}"
-}
-
-# Grant Masthead service account the custom Dataplex locations role
-resource "google_project_iam_member" "masthead_dataplex_custom_role" {
-  project = var.project_id
-  role    = google_project_iam_custom_role.masthead_dataplex_locations.id
   member  = "serviceAccount:${var.masthead_service_accounts.dataplex_sa}"
 }

--- a/modules/dataplex/outputs.tf
+++ b/modules/dataplex/outputs.tf
@@ -17,8 +17,3 @@ output "logging_sink_writer_identity" {
   description = "Writer identity of the logging sink"
   value       = google_logging_project_sink.masthead_dataplex_sink.writer_identity
 }
-
-output "custom_role_id" {
-  description = "ID of the custom IAM role for Dataplex locations"
-  value       = google_project_iam_custom_role.masthead_dataplex_locations.role_id
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,6 @@ output "dataplex" {
     pubsub_subscription_id       = module.dataplex[0].pubsub_subscription_id
     logging_sink_id              = module.dataplex[0].logging_sink_id
     logging_sink_writer_identity = module.dataplex[0].logging_sink_writer_identity
-    custom_role_id               = module.dataplex[0].custom_role_id
   } : null
 }
 


### PR DESCRIPTION
This pull request removes the custom IAM role previously used for Dataplex locations access from the Terraform module and updates related documentation and outputs. The change streamlines permissions management by relying on predefined roles instead of a custom one.

**IAM Role Removal:**
* Removed the `google_project_iam_custom_role.masthead_dataplex_locations` resource and its associated IAM binding from `modules/dataplex/main.tf`, eliminating the creation and assignment of the custom Dataplex locations role. [[1]](diffhunk://#diff-88f2271ef40bc7c90cd1051ee76f13f700e82df9c13095f1772df63301d7cf24L102-L117) [[2]](diffhunk://#diff-88f2271ef40bc7c90cd1051ee76f13f700e82df9c13095f1772df63301d7cf24L130-L136)
* Removed the `custom_role_id` output from both `modules/dataplex/outputs.tf` and the root `outputs.tf` file, as the custom role is no longer created or needed. [[1]](diffhunk://#diff-477549dba1f0d3eef212d0a5fd56c247aa5418e69cb8d575425e7821a2e7fe16L20-L24) [[2]](diffhunk://#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7L28)
* Removed the `custom_role_id` local variable from `modules/dataplex/main.tf`.

**Documentation Updates:**
* Updated `modules/dataplex/README.md` to remove mention of the custom IAM role from the list of provisioned resources.
* Updated `CHANGELOG.md` to document the removal of the custom IAM role in version 0.2.5 and updated version references. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR22-R27) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL115-R122)