### PR TITLE
Unify Dataplex IAM roles to always include data scan editing by removing the `enable_datascan_editing` variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `enable_datascan_editing` flag is now deprecated and unused, as Dataplex IAM roles have been unified into an unchangeable set.
+
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- `enable_datascan_editing` flag is now deprecated and unused, as Dataplex IAM roles have been unified into an unchangeable set.
+- `enable_datascan_editing` flag is now deprecated and removed, as Dataplex IAM roles have been unified into an unchangeable set.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ module "masthead_agent" {
   # Optional features
   enable_apis                  = true
   enable_privatelogviewer_role = true  # For retrospective log export
-  enable_datascan_editing      = false # Dataplex DataScan editing permissions
 
   # Labels for governance and cost management
   labels = {

--- a/examples/org-mode.tfvars.example
+++ b/examples/org-mode.tfvars.example
@@ -30,7 +30,6 @@ enable_modules = {
 # Optional configurations
 enable_privatelogviewer_role = true
 enable_apis                  = true
-enable_datascan_editing      = false
 
 # Labels
 labels = {

--- a/examples/project-mode.tfvars.example
+++ b/examples/project-mode.tfvars.example
@@ -15,7 +15,6 @@ enable_modules = {
 # Optional configurations
 enable_privatelogviewer_role = true
 enable_apis                  = true
-enable_datascan_editing      = false
 
 # Labels
 labels = {

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,6 @@ module "dataplex" {
 
   # Service account and permissions
   masthead_service_accounts = var.masthead_service_accounts
-  enable_datascan_editing   = var.enable_datascan_editing
 
   # Resource configuration
   enable_apis = var.enable_apis

--- a/modules/dataplex/main.tf
+++ b/modules/dataplex/main.tf
@@ -33,15 +33,11 @@ EOT
   iam_target_projects = local.has_folders ? [] : var.monitored_project_ids
 
   # Determine roles based on editing permissions
-  dataplex_roles = var.enable_datascan_editing ? toset([
+  dataplex_roles = toset([
+    "roles/bigquery.jobUser",
     "roles/dataplex.dataProductsViewer",
     "roles/dataplex.dataScanDataViewer",
-    "roles/dataplex.dataScanEditor",
-    "roles/bigquery.jobUser",
-    "roles/dataplex.storageDataReader"
-    ]) : toset([
-    "roles/dataplex.dataProductsViewer",
-    "roles/dataplex.dataScanDataViewer"
+    "roles/dataplex.dataScanEditor"
   ])
 }
 

--- a/modules/dataplex/variables.tf
+++ b/modules/dataplex/variables.tf
@@ -22,12 +22,6 @@ variable "masthead_service_accounts" {
   description = "Masthead service account emails"
 }
 
-variable "enable_datascan_editing" {
-  type        = bool
-  description = "Enable permissions for creating and editing Dataplex DataScans"
-  default     = false
-}
-
 variable "enable_apis" {
   type        = bool
   description = "Enable required Google Cloud APIs"

--- a/variables.tf
+++ b/variables.tf
@@ -124,12 +124,6 @@ variable "enable_apis" {
   default     = true
 }
 
-variable "enable_datascan_editing" {
-  type        = bool
-  description = "Enable permissions for creating and editing Dataplex DataScans"
-  default     = false
-}
-
 variable "labels" {
   type        = map(string)
   description = "Labels to apply to resources"


### PR DESCRIPTION
This pull request removes the now-deprecated `enable_datascan_editing` flag from the codebase, documentation, and configuration examples. Dataplex IAM roles are now always assigned as a unified, unchangeable set, simplifying permissions management and reducing configuration complexity.

**Deprecation and Removal of DataScan Editing Flag:**

* Deprecated the `enable_datascan_editing` flag, noting it is unused due to unified Dataplex IAM roles. (`CHANGELOG.md`)
* Removed the `enable_datascan_editing` variable from the main module and Dataplex submodule, including all references in `variables.tf`, `modules/dataplex/variables.tf`, and `main.tf`.
* Updated the Dataplex roles assignment logic to always grant the full set of roles, regardless of any editing flag. (`modules/dataplex/main.tf`)

**Documentation and Example Updates:**

* Removed mentions of `enable_datascan_editing` from the README and example configuration files to reflect the simplified permissions model. (`README.md`, `examples/org-mode.tfvars.example`, `examples/project-mode.tfvars.example`)