### PR TITLE
feat: add PII redaction configuration for BigQuery logging infrastructure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,7 @@ This is a Terraform module that deploys infrastructure for Masthead Data to moni
 ### File Organization
 - Each module should have: `main.tf`, `variables.tf`, `outputs.tf`, `versions.tf`, and `README.md`
 - Root level should have: `main.tf`, `variables.tf`, `outputs.tf`, and `README.md`
+- Extended documentation lives in `docs/`: `docs/configuration.md` (full config reference + optional features) and `docs/architecture.md` (diagrams)
 - Keep related resources together in logical blocks with comments
 
 ### Variable Conventions
@@ -132,6 +133,30 @@ locals {
   })
 }
 ```
+
+### Opt-in Features via `custom_code`
+For features that require user-supplied logic (e.g., Pub/Sub message transforms), use a `custom_code` field in an object variable rather than an `enabled` boolean. Enable the underlying resource only when the value is non-null:
+```hcl
+# Variable shape
+variable "pii_redaction" {
+  type = object({
+    custom_code = optional(string, null)
+  })
+  default = {}
+}
+
+# Conditional dynamic block
+dynamic "message_transforms" {
+  for_each = var.pii_redaction.custom_code != null ? [1] : []
+  content {
+    javascript_udf {
+      function_name = "redactPii"
+      code          = var.pii_redaction.custom_code
+    }
+  }
+}
+```
+The UDF function name must match what the resource expects (e.g., `"redactPii"` for `google_pubsub_topic.message_transforms`).
 
 ### API Enablement
 ```hcl

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -169,7 +169,7 @@ Required APIs per module:
 - Maintain semantic versioning (MAJOR.MINOR.PATCH)
 - Update CHANGELOG.md for all changes
 - Keep minimum Terraform version at 1.5.7+
-- Keep minimum Google provider version at 6.13.0+
+- Keep minimum Google provider version at 6.39.0+
 - Test compatibility with latest provider versions
 
 ## When Making Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **PII Redaction via Pub/Sub SMT**: Added opt-in `pii_redaction` variable to the BigQuery module. When enabled, a JavaScript UDF runs as a Pub/Sub message transform on the BigQuery topic and redacts email addresses from SQL query fields (`jobInsertRequest`, `jobUpdateRequest`, `jobQueryResponse`) in BigQuery audit log entries before messages are stored in the subscription backlog. A `custom_code` field allows supplying a fully custom UDF instead of the built-in email-redaction logic.
 
+### Changed
+
+- Bumped minimum Google provider version from `6.13.0` to `6.39.0` to support `message_transforms` on `google_pubsub_topic` (added in provider 6.39.0)
+
 ### Removed
 
 - **Dataplex IAM**: Removed `roles/dataplex.storageDataReader` role from Dataplex service account permissions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **Dataplex IAM**: Removed `roles/dataplex.storageDataReader` role from Dataplex service account permissions
-
 ### Fixed
 
 ### Security
+
+## [0.3.1] - 2026-04-07
+
+### Added
+
+- **PII Redaction via Pub/Sub SMT**: Added opt-in `pii_redaction` variable to the BigQuery module. When enabled, a JavaScript UDF runs as a Pub/Sub message transform on the BigQuery topic and redacts email addresses from SQL query fields (`jobInsertRequest`, `jobUpdateRequest`, `jobQueryResponse`) in BigQuery audit log entries before messages are stored in the subscription backlog. A `custom_code` field allows supplying a fully custom UDF instead of the built-in email-redaction logic.
+
+### Removed
+
+- **Dataplex IAM**: Removed `roles/dataplex.storageDataReader` role from Dataplex service account permissions
 
 ## [0.3.0] - 2026-02-10
 

--- a/README.md
+++ b/README.md
@@ -66,14 +66,6 @@ module "masthead_agent" {
 }
 ```
 
-### Full Configuration Example
-
-See [docs/full-configuration.md](docs/full-configuration.md) for a complete configuration with all available options, including PII redaction.
-
-## Architecture
-
-See [docs/architecture.md](docs/architecture.md) for diagrams and details.
-
 ## Required GCP Permissions
 
 ### For Project Mode
@@ -103,6 +95,11 @@ You need these permissions in the target project:
 - `pubsub.subscriptions.create`
 - `iam.serviceAccounts.setIamPolicy`
 - `resourcemanager.projects.setIamPolicy`
+
+### Documentation
+
+- [Configuration](docs/configuration.md)
+- [Architecture](docs/architecture.md)
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For multi-project or folder-level monitoring. Creates centralized Pub/Sub infras
 ```hcl
 module "masthead_agent" {
   source  = "masthead-data/masthead-agent/google"
-  version = ">=0.3.0"
+  version = ">=0.3.1"
 
   # Project mode: single project
   project_id = "project-1"
@@ -46,7 +46,7 @@ module "masthead_agent" {
 ```hcl
 module "masthead_agent" {
   source  = "masthead-data/masthead-agent/google"
-  version = ">=0.3.0"
+  version = ">=0.3.1"
 
   # Organization mode: folders + additional projects
   monitored_folder_ids  = [
@@ -73,7 +73,7 @@ Complete configuration with all options:
 ```hcl
 module "masthead_agent" {
   source  = "masthead-data/masthead-agent/google"
-  version = ">=0.3.0"
+  version = ">=0.3.1"
 
   # Choose ONE mode:
 

--- a/README.md
+++ b/README.md
@@ -68,112 +68,11 @@ module "masthead_agent" {
 
 ### Full Configuration Example
 
-Complete configuration with all options:
-
-```hcl
-module "masthead_agent" {
-  source  = "masthead-data/masthead-agent/google"
-  version = ">=0.3.1"
-
-  # Choose ONE mode:
-
-  # PROJECT MODE: Set project_id only
-  project_id = var.project_id
-
-  # ORGANIZATION MODE: Set deployment_project_id + folders and/or projects
-  # deployment_project_id = var.deployment_project_id
-  # monitored_folder_ids  = ["folders/123456789"]  # Optional: monitor folders
-  # monitored_project_ids = ["project-1", "project-2"]  # Optional: monitor specific projects
-  # organization_id       = "123456789"  # Required when using folders
-
-  # Module configuration
-  enable_modules = {
-    bigquery      = true
-    dataform      = true
-    dataplex      = true
-    analytics_hub = true
-  }
-
-  # Optional features
-  enable_apis                  = true
-  enable_privatelogviewer_role = true  # For retrospective log export
-  enable_datascan_editing      = false # Dataplex DataScan editing permissions
-
-  # Labels for governance and cost management
-  labels = {
-    environment = "production"
-    team        = "data"
-    cost_center = "engineering"
-    monitoring  = "masthead"
-  }
-}
-```
+See [docs/full-configuration.md](docs/full-configuration.md) for a complete configuration with all available options, including PII redaction.
 
 ## Architecture
 
-### Project Mode
-
-```text
-┌─────────────────────────────────────┐
-│        Single GCP Project           │
-│                                     │
-│  ┌──────────────┐  ┌─────────────┐  │
-│  │ Log Sinks    │→ │   Pub/Sub   │  │
-│  │ (Project)    │  │   Topics    │  │
-│  └──────────────┘  └─────────────┘  │
-│         ↓                ↓          │
-│  ┌──────────────────────────────┐   │
-│  │       IAM Bindings           │   │
-│  └──────────────────────────────┘   │
-└─────────────────────────────────────┘
-```
-
-### Organization Mode
-
-```text
-┌────────────────────────────────────────┐
-│        GCP Folder(s) (optional)        │
-│  ┌──────────────────────────────────┐  │
-│  │  All Child Projects              │  │
-│  └──────────────────────────────────┘  │
-│              ↓                         │
-│  ┌──────────────────────────────────┐  │
-│  │  Folder-Level Log Sinks          │  │
-│  │  + IAM Bindings (inherited)      │  │
-│  └──────────────────────────────────┘  │
-└────────────────────────────────────────┘
-              ↓
-┌────────────────────────────────────────┐
-│     Additional Projects (optional)     │
-│  ┌──────────────────────────────────┐  │
-│  │  Project-Level Log Sinks         │  │
-│  │  + IAM Bindings                  │  │
-│  └──────────────────────────────────┘  │
-└────────────────────────────────────────┘
-              ↓
-┌────────────────────────────────────────┐
-│           Deployment Project           │
-│  ┌──────────────────────────────────┐  │
-│  │  Centralized Pub/Sub Topics      │  │
-│  │  + Subscriptions                 │  │
-│  └──────────────────────────────────┘  │
-└────────────────────────────────────────┘
-```
-
-## How It Works
-
-### Project Mode
-
-- IAM bindings applied at the **project level**
-- Log sinks created at the **project level**
-- All resources in one project
-
-### Organization Mode
-
-- **For folders**: IAM bindings applied at **folder level** (inherited by all child projects)
-- **For folders**: Log sinks created at **folder level**
-- **For additional projects**: IAM bindings and log sinks applied at **project level**
-- Centralized Pub/Sub in deployment project
+See [docs/architecture.md](docs/architecture.md) for diagrams and details.
 
 ## Required GCP Permissions
 

--- a/README.md
+++ b/README.md
@@ -6,30 +6,13 @@
 
 This Terraform module deploys infrastructure for Masthead Data to monitor Google Cloud services (BigQuery, Dataform, Dataplex, Analytics Hub) using Pub/Sub topics, Cloud Logging sinks, and IAM bindings.
 
-## Deployment Modes
-
-The module supports two deployment modes:
-
-### 📦 Project Mode
+## 📦 Project Mode
 
 For single-project setups. All resources (logs, Pub/Sub, IAM) are created in a monitored project.
 
 **Use when:** You have a single project or a few projects to monitor.
 
-### 🏢 Organization Mode
-
-For multi-project or folder-level monitoring. Creates centralized Pub/Sub infrastructure in a dedicated deployment project with folder-level and/or project-level log sinks.
-
-**Supports:**
-- One or more GCP folders (monitors all child projects)
-- Additional individual projects (outside of folders)
-- Any combination of folders and projects
-
-**Use when:** You want to monitor multiple projects, use GCP folders, or need centralized log collection.
-
-## Usage Examples
-
-### Project Mode
+### Example
 
 ```hcl
 module "masthead_agent" {
@@ -41,7 +24,32 @@ module "masthead_agent" {
 }
 ```
 
-### Organization Mode
+### Required Permissions
+
+**Target project:**
+
+- `iam.roles.create`
+- `logging.sinks.create`
+- `pubsub.subscriptions.create`
+- `pubsub.subscriptions.setIamPolicy`
+- `pubsub.topics.create`
+- `pubsub.topics.setIamPolicy`
+- `resourcemanager.projects.setIamPolicy`
+- `serviceusage.services.enable`
+
+## 🏢 Organization Mode
+
+For multi-project or folder-level monitoring. Creates centralized Pub/Sub infrastructure in a dedicated deployment project with folder-level and/or project-level log sinks.
+
+**Supports:**
+
+- One or more GCP folders (monitors all child projects)
+- Additional individual projects (outside of folders)
+- Any combination of folders and projects
+
+**Use when:** You want to monitor multiple projects, use GCP folders, or need centralized log collection.
+
+### Example
 
 ```hcl
 module "masthead_agent" {
@@ -66,37 +74,33 @@ module "masthead_agent" {
 }
 ```
 
-## Required GCP Permissions
+### Required Permissions
 
-### For Project Mode
+**Deployment project**:
 
-You need these permissions in the target project:
+- `pubsub.subscriptions.create`
+- `pubsub.subscriptions.setIamPolicy`
+- `pubsub.topics.create`
+- `pubsub.topics.setIamPolicy`
+- `serviceusage.services.enable`
+
+**Each monitored project** (when `monitored_project_ids` is set):
+
+- `iam.roles.create`
+- `logging.sinks.create`
+- `resourcemanager.projects.setIamPolicy`
+- `serviceusage.services.enable`
+
+**Each monitored folder**:
 
 - `logging.sinks.create`
-- `pubsub.topics.create`
-- `pubsub.subscriptions.create`
-- `iam.serviceAccounts.setIamPolicy`
-- `resourcemanager.projects.setIamPolicy`
+- `resourcemanager.folders.setIamPolicy`
 
-### For Organization Mode
+**Organization level** (when `monitored_folder_ids` is set and `organization_id` is provided):
 
-**When using folders**, you need these permissions at the folder level:
+- `iam.roles.create`
 
-- `logging.sinks.create` (on folder)
-- `resourcemanager.folders.setIamPolicy` (on folder)
-
-**When using folders**, you need these permissions at the organization level:
-
-- `iam.roles.create` (on organization) - Required for creating custom IAM roles
-
-**Always required** for the deployment project:
-
-- `pubsub.topics.create`
-- `pubsub.subscriptions.create`
-- `iam.serviceAccounts.setIamPolicy`
-- `resourcemanager.projects.setIamPolicy`
-
-### Documentation
+## Documentation
 
 - [Configuration](docs/configuration.md)
 - [Architecture](docs/architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,59 @@
+# Architecture
+
+## Project Mode
+
+```text
+┌─────────────────────────────────────┐
+│        Single GCP Project           │
+│                                     │
+│  ┌──────────────┐  ┌─────────────┐  │
+│  │ Log Sinks    │→ │   Pub/Sub   │  │
+│  │ (Project)    │  │   Topics    │  │
+│  └──────────────┘  └─────────────┘  │
+│         ↓                ↓          │
+│  ┌──────────────────────────────┐   │
+│  │       IAM Bindings           │   │
+│  └──────────────────────────────┘   │
+└─────────────────────────────────────┘
+```
+
+- IAM bindings applied at the **project level**
+- Log sinks created at the **project level**
+- All resources in one project
+
+## Organization Mode
+
+```text
+┌────────────────────────────────────────┐
+│        GCP Folder(s) (optional)        │
+│  ┌──────────────────────────────────┐  │
+│  │  All Child Projects              │  │
+│  └──────────────────────────────────┘  │
+│              ↓                         │
+│  ┌──────────────────────────────────┐  │
+│  │  Folder-Level Log Sinks          │  │
+│  │  + IAM Bindings (inherited)      │  │
+│  └──────────────────────────────────┘  │
+└────────────────────────────────────────┘
+              ↓
+┌────────────────────────────────────────┐
+│     Additional Projects (optional)     │
+│  ┌──────────────────────────────────┐  │
+│  │  Project-Level Log Sinks         │  │
+│  │  + IAM Bindings                  │  │
+│  └──────────────────────────────────┘  │
+└────────────────────────────────────────┘
+              ↓
+┌────────────────────────────────────────┐
+│           Deployment Project           │
+│  ┌──────────────────────────────────┐  │
+│  │  Centralized Pub/Sub Topics      │  │
+│  │  + Subscriptions                 │  │
+│  └──────────────────────────────────┘  │
+└────────────────────────────────────────┘
+```
+
+- **For folders**: IAM bindings applied at **folder level** (inherited by all child projects)
+- **For folders**: Log sinks created at **folder level**
+- **For additional projects**: IAM bindings and log sinks applied at **project level**
+- Centralized Pub/Sub in deployment project

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,48 +55,48 @@ The BigQuery module supports opt-in PII redaction via a [Pub/Sub message transfo
 
 The SMT is disabled by default. It is enabled only when `pii_redaction.custom_code` is set.
 
-### Email address redaction (starter template)
+### PII redaction starter template
 
-The following UDF redacts email addresses from BigQuery audit log SQL query fields (`jobInsertRequest`, `jobUpdateRequest`, `jobQueryResponse`). Copy and customise as needed.
+The following UDF redacts PII patterns from BigQuery audit log SQL query fields. Copy and customise as needed.
 
 ```hcl
 pii_redaction = {
   custom_code = <<-JAVASCRIPT
     function redactPii(message, metadata) {
-      if (!message.data) return message;
       try {
-        var bytes = message.data;
-        var text = '';
-        for (var bi = 0; bi < bytes.length; bi++) {
-          text += String.fromCharCode(bytes[bi]);
-        }
-        var log = JSON.parse(text);
-        var emailRegex = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
-        var paths = [
-          ['protoPayload', 'serviceData', 'jobInsertRequest', 'resource', 'jobConfiguration', 'query', 'query'],
-          ['protoPayload', 'serviceData', 'jobUpdateRequest', 'resource', 'jobConfiguration', 'query', 'query'],
-          ['protoPayload', 'serviceData', 'jobQueryResponse', 'resource', 'jobConfiguration', 'query', 'query']
-        ];
-        for (var pi = 0; pi < paths.length; pi++) {
-          var obj = log;
-          var path = paths[pi];
-          for (var ki = 0; ki < path.length - 1; ki++) {
-            if (obj == null || typeof obj !== 'object') { obj = null; break; }
-            obj = obj[path[ki]];
+        var data = JSON.parse(message.data);
+
+        function safeGet(obj, keys) {
+          var current = obj;
+          for (var i = 0; i < keys.length; i++) {
+            if (current == null || typeof current !== "object") return null;
+            current = current[keys[i]];
           }
-          var key = path[path.length - 1];
-          if (obj != null && typeof obj === 'object' && typeof obj[key] === 'string') {
-            obj[key] = obj[key].replace(emailRegex, '[REDACTED]');
-          }
+          return current != null ? current : null;
         }
-        var encoded = JSON.stringify(log);
-        var result = new Uint8Array(encoded.length);
-        for (var ei = 0; ei < encoded.length; ei++) {
-          result[ei] = encoded.charCodeAt(ei);
+
+        function maskText(text) {
+          if (!text) return text;
+          text = text.replace(/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g, "[EMAIL_ADDRESS]");
+
+          // Add more regex patterns for other PII types as needed
+
+          return text;
         }
-        message.data = result;
-      } catch (e) {}
-      return message;
+
+        function maskFields(config) {
+          if (config == null) return;
+          if (typeof config.query === "string") config.query = maskText(config.query);
+        }
+
+        maskFields(safeGet(data, ["protoPayload", "metadata", "jobChange", "job", "jobConfig", "queryConfig"]));
+        maskFields(safeGet(data, ["protoPayload", "metadata", "jobInsertion", "job", "jobConfig", "queryConfig"]));
+
+        message.data = JSON.stringify(data);
+        return message;
+      } catch (e) {
+        return message;
+      }
     }
   JAVASCRIPT
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
-# Full Configuration Example
+# Configuration
 
-Complete configuration with all available options:
+Configuration example with all available options:
 
 ```hcl
 module "masthead_agent" {
@@ -13,10 +13,10 @@ module "masthead_agent" {
   project_id = var.project_id
 
   # ORGANIZATION MODE: Set deployment_project_id + folders and/or projects
-  # deployment_project_id = var.deployment_project_id
-  # monitored_folder_ids  = ["folders/123456789"]  # Optional: monitor folders
-  # monitored_project_ids = ["project-1", "project-2"]  # Optional: monitor specific projects
-  # organization_id       = "123456789"  # Required when using folders
+  deployment_project_id = var.deployment_project_id
+  monitored_folder_ids  = ["folders/123456789"]  # Optional: monitor folders
+  monitored_project_ids = ["project-1", "project-2"]  # Optional: monitor specific projects
+  organization_id       = "123456789"  # Required when using folders
 
   # Module configuration
   enable_modules = {
@@ -33,11 +33,11 @@ module "masthead_agent" {
 
   # PII redaction (optional) — provide a UDF to enable SMT on the BigQuery topic
   # See ## PII Redaction below for a ready-to-use email redaction example
-  # pii_redaction = {
-  #   custom_code = <<-JAVASCRIPT
-  #     function redactPii(message, metadata) { ... }
-  #   JAVASCRIPT
-  # }
+  pii_redaction = {
+    custom_code = <<-JAVASCRIPT
+      function redactPii(message, metadata) { ... }
+    JAVASCRIPT
+  }
 
   # Labels for governance and cost management
   labels = {

--- a/docs/full-configuration.md
+++ b/docs/full-configuration.md
@@ -1,0 +1,110 @@
+# Full Configuration Example
+
+Complete configuration with all available options:
+
+```hcl
+module "masthead_agent" {
+  source  = "masthead-data/masthead-agent/google"
+  version = ">=0.3.1"
+
+  # Choose ONE mode:
+
+  # PROJECT MODE: Set project_id only
+  project_id = var.project_id
+
+  # ORGANIZATION MODE: Set deployment_project_id + folders and/or projects
+  # deployment_project_id = var.deployment_project_id
+  # monitored_folder_ids  = ["folders/123456789"]  # Optional: monitor folders
+  # monitored_project_ids = ["project-1", "project-2"]  # Optional: monitor specific projects
+  # organization_id       = "123456789"  # Required when using folders
+
+  # Module configuration
+  enable_modules = {
+    bigquery      = true
+    dataform      = true
+    dataplex      = true
+    analytics_hub = true
+  }
+
+  # Optional features
+  enable_apis                  = true
+  enable_privatelogviewer_role = true  # For retrospective log export
+  enable_datascan_editing      = false # Dataplex DataScan editing permissions
+
+  # PII redaction (optional) — provide a UDF to enable SMT on the BigQuery topic
+  # See ## PII Redaction below for a ready-to-use email redaction example
+  # pii_redaction = {
+  #   custom_code = <<-JAVASCRIPT
+  #     function redactPii(message, metadata) { ... }
+  #   JAVASCRIPT
+  # }
+
+  # Labels for governance and cost management
+  labels = {
+    environment = "production"
+    team        = "data"
+    cost_center = "engineering"
+    monitoring  = "masthead"
+  }
+}
+```
+
+## PII Redaction
+
+The BigQuery module supports opt-in PII redaction via a [Pub/Sub message transform (SMT)](https://cloud.google.com/pubsub/docs/message-transforms). A JavaScript UDF runs at the **topic level**, so all subscribers receive redacted messages before they are stored in the subscription backlog.
+
+The SMT is disabled by default. It is enabled only when `pii_redaction.custom_code` is set.
+
+### Email address redaction (starter template)
+
+The following UDF redacts email addresses from BigQuery audit log SQL query fields (`jobInsertRequest`, `jobUpdateRequest`, `jobQueryResponse`). Copy and customise as needed.
+
+```hcl
+pii_redaction = {
+  custom_code = <<-JAVASCRIPT
+    function redactPii(message, metadata) {
+      if (!message.data) return message;
+      try {
+        var bytes = message.data;
+        var text = '';
+        for (var bi = 0; bi < bytes.length; bi++) {
+          text += String.fromCharCode(bytes[bi]);
+        }
+        var log = JSON.parse(text);
+        var emailRegex = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
+        var paths = [
+          ['protoPayload', 'serviceData', 'jobInsertRequest', 'resource', 'jobConfiguration', 'query', 'query'],
+          ['protoPayload', 'serviceData', 'jobUpdateRequest', 'resource', 'jobConfiguration', 'query', 'query'],
+          ['protoPayload', 'serviceData', 'jobQueryResponse', 'resource', 'jobConfiguration', 'query', 'query']
+        ];
+        for (var pi = 0; pi < paths.length; pi++) {
+          var obj = log;
+          var path = paths[pi];
+          for (var ki = 0; ki < path.length - 1; ki++) {
+            if (obj == null || typeof obj !== 'object') { obj = null; break; }
+            obj = obj[path[ki]];
+          }
+          var key = path[path.length - 1];
+          if (obj != null && typeof obj === 'object' && typeof obj[key] === 'string') {
+            obj[key] = obj[key].replace(emailRegex, '[REDACTED]');
+          }
+        }
+        var encoded = JSON.stringify(log);
+        var result = new Uint8Array(encoded.length);
+        for (var ei = 0; ei < encoded.length; ei++) {
+          result[ei] = encoded.charCodeAt(ei);
+        }
+        message.data = result;
+      } catch (e) {}
+      return message;
+    }
+  JAVASCRIPT
+}
+```
+
+### Behaviour details
+
+- Disabled by default. The SMT is enabled only when `custom_code` is provided.
+- The UDF must export a function named `redactPii(message, metadata)` matching the [Pub/Sub SMT UDF signature](https://cloud.google.com/pubsub/docs/message-transforms#javascript-udf).
+- The transform runs on the **topic**, so all subscribers automatically receive redacted messages.
+- Only applies to the BigQuery module. Other modules (Dataform, Dataplex) are unaffected.

--- a/examples/pulumi-script/Pulumi.yaml
+++ b/examples/pulumi-script/Pulumi.yaml
@@ -11,5 +11,5 @@ packages:
     version: 0.1.8
     parameters:
       - masthead-data/masthead-agent/google
-      - 0.3.0
+      - 0.3.1
       - masthead-agent

--- a/main.tf
+++ b/main.tf
@@ -53,8 +53,9 @@ module "bigquery" {
   enable_privatelogviewer_role = var.enable_privatelogviewer_role
 
   # Resource configuration
-  enable_apis = var.enable_apis
-  labels      = var.labels
+  enable_apis   = var.enable_apis
+  labels        = var.labels
+  pii_redaction = var.pii_redaction
 }
 
 # Dataform Module - Logging Infrastructure + IAM

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.13.0"
+      version = ">= 6.39.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/analytics-hub/versions.tf
+++ b/modules/analytics-hub/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.13.0"
+      version = ">= 6.39.0"
     }
   }
 }

--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -62,6 +62,7 @@ module "logging_infrastructure" {
   masthead_service_account = var.masthead_service_accounts.bigquery_sa
   enable_apis              = var.enable_apis
   labels                   = local.common_labels
+  pii_redaction            = var.pii_redaction
 }
 
 # IAM: Grant Masthead service account required BigQuery roles at folder level

--- a/modules/bigquery/variables.tf
+++ b/modules/bigquery/variables.tf
@@ -46,3 +46,12 @@ variable "labels" {
   description = "Labels to apply to resources"
   default     = {}
 }
+
+variable "pii_redaction" {
+  description = "PII redaction configuration using a Pub/Sub message transform (SMT) applied to the BigQuery topic. When enabled, a JavaScript UDF redacts email addresses from SQL query fields before messages are stored."
+  type = object({
+    enabled     = optional(bool, false)
+    custom_code = optional(string, null)
+  })
+  default = {}
+}

--- a/modules/bigquery/variables.tf
+++ b/modules/bigquery/variables.tf
@@ -48,9 +48,8 @@ variable "labels" {
 }
 
 variable "pii_redaction" {
-  description = "PII redaction configuration using a Pub/Sub message transform (SMT) applied to the BigQuery topic. When enabled, a JavaScript UDF redacts email addresses from SQL query fields before messages are stored."
+  description = "PII redaction configuration. Provide custom_code with a JavaScript UDF to enable a Pub/Sub message transform (SMT) on the BigQuery topic. The SMT is disabled when custom_code is null."
   type = object({
-    enabled     = optional(bool, false)
     custom_code = optional(string, null)
   })
   default = {}

--- a/modules/bigquery/versions.tf
+++ b/modules/bigquery/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.13.0"
+      version = ">= 6.39.0"
     }
   }
 }

--- a/modules/dataform/versions.tf
+++ b/modules/dataform/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.13.0"
+      version = ">= 6.39.0"
     }
   }
 }

--- a/modules/dataplex/versions.tf
+++ b/modules/dataplex/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.13.0"
+      version = ">= 6.39.0"
     }
   }
 }

--- a/modules/logging-infrastructure/main.tf
+++ b/modules/logging-infrastructure/main.tf
@@ -13,6 +13,48 @@ locals {
   common_labels = merge(var.labels, {
     component = var.component_name
   })
+
+  # Default PII redaction UDF — redacts email addresses from BigQuery SQL query fields
+  pii_udf_default_code = <<-JAVASCRIPT
+    function redactPii(message, metadata) {
+      if (!message.data) return message;
+      try {
+        var bytes = message.data;
+        var text = '';
+        for (var bi = 0; bi < bytes.length; bi++) {
+          text += String.fromCharCode(bytes[bi]);
+        }
+        var log = JSON.parse(text);
+        var emailRegex = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
+        var paths = [
+          ['protoPayload', 'serviceData', 'jobInsertRequest', 'resource', 'jobConfiguration', 'query', 'query'],
+          ['protoPayload', 'serviceData', 'jobUpdateRequest', 'resource', 'jobConfiguration', 'query', 'query'],
+          ['protoPayload', 'serviceData', 'jobQueryResponse', 'resource', 'jobConfiguration', 'query', 'query']
+        ];
+        for (var pi = 0; pi < paths.length; pi++) {
+          var obj = log;
+          var path = paths[pi];
+          for (var ki = 0; ki < path.length - 1; ki++) {
+            if (obj == null || typeof obj !== 'object') { obj = null; break; }
+            obj = obj[path[ki]];
+          }
+          var key = path[path.length - 1];
+          if (obj != null && typeof obj === 'object' && typeof obj[key] === 'string') {
+            obj[key] = obj[key].replace(emailRegex, '[REDACTED]');
+          }
+        }
+        var encoded = JSON.stringify(log);
+        var result = new Uint8Array(encoded.length);
+        for (var ei = 0; ei < encoded.length; ei++) {
+          result[ei] = encoded.charCodeAt(ei);
+        }
+        message.data = result;
+      } catch (e) {}
+      return message;
+    }
+  JAVASCRIPT
+
+  pii_udf_code = var.pii_redaction.custom_code != null ? var.pii_redaction.custom_code : local.pii_udf_default_code
 }
 
 # Enable Pub/Sub API in the deployment project
@@ -50,6 +92,16 @@ resource "google_pubsub_topic" "logs_topic" {
   name    = var.topic_name
 
   labels = local.common_labels
+
+  dynamic "message_transforms" {
+    for_each = var.pii_redaction.enabled ? [1] : []
+    content {
+      javascript_udf {
+        function_name = "redactPii"
+        code          = local.pii_udf_code
+      }
+    }
+  }
 }
 
 # Create Pub/Sub subscription in the deployment project

--- a/modules/logging-infrastructure/main.tf
+++ b/modules/logging-infrastructure/main.tf
@@ -13,48 +13,6 @@ locals {
   common_labels = merge(var.labels, {
     component = var.component_name
   })
-
-  # Default PII redaction UDF — redacts email addresses from BigQuery SQL query fields
-  pii_udf_default_code = <<-JAVASCRIPT
-    function redactPii(message, metadata) {
-      if (!message.data) return message;
-      try {
-        var bytes = message.data;
-        var text = '';
-        for (var bi = 0; bi < bytes.length; bi++) {
-          text += String.fromCharCode(bytes[bi]);
-        }
-        var log = JSON.parse(text);
-        var emailRegex = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
-        var paths = [
-          ['protoPayload', 'serviceData', 'jobInsertRequest', 'resource', 'jobConfiguration', 'query', 'query'],
-          ['protoPayload', 'serviceData', 'jobUpdateRequest', 'resource', 'jobConfiguration', 'query', 'query'],
-          ['protoPayload', 'serviceData', 'jobQueryResponse', 'resource', 'jobConfiguration', 'query', 'query']
-        ];
-        for (var pi = 0; pi < paths.length; pi++) {
-          var obj = log;
-          var path = paths[pi];
-          for (var ki = 0; ki < path.length - 1; ki++) {
-            if (obj == null || typeof obj !== 'object') { obj = null; break; }
-            obj = obj[path[ki]];
-          }
-          var key = path[path.length - 1];
-          if (obj != null && typeof obj === 'object' && typeof obj[key] === 'string') {
-            obj[key] = obj[key].replace(emailRegex, '[REDACTED]');
-          }
-        }
-        var encoded = JSON.stringify(log);
-        var result = new Uint8Array(encoded.length);
-        for (var ei = 0; ei < encoded.length; ei++) {
-          result[ei] = encoded.charCodeAt(ei);
-        }
-        message.data = result;
-      } catch (e) {}
-      return message;
-    }
-  JAVASCRIPT
-
-  pii_udf_code = var.pii_redaction.custom_code != null ? var.pii_redaction.custom_code : local.pii_udf_default_code
 }
 
 # Enable Pub/Sub API in the deployment project
@@ -94,11 +52,11 @@ resource "google_pubsub_topic" "logs_topic" {
   labels = local.common_labels
 
   dynamic "message_transforms" {
-    for_each = var.pii_redaction.enabled ? [1] : []
+    for_each = var.pii_redaction.custom_code != null ? [1] : []
     content {
       javascript_udf {
         function_name = "redactPii"
-        code          = local.pii_udf_code
+        code          = var.pii_redaction.custom_code
       }
     }
   }

--- a/modules/logging-infrastructure/variables.tf
+++ b/modules/logging-infrastructure/variables.tf
@@ -58,9 +58,8 @@ variable "labels" {
 }
 
 variable "pii_redaction" {
-  description = "PII redaction configuration using a Pub/Sub message transform (SMT) applied to the topic. When enabled, a JavaScript UDF redacts email addresses from BigQuery SQL query fields before messages are stored in the subscription backlog."
+  description = "PII redaction configuration. Provide custom_code with a JavaScript UDF to enable a Pub/Sub message transform (SMT) on the topic. The SMT is disabled when custom_code is null."
   type = object({
-    enabled     = optional(bool, false)
     custom_code = optional(string, null)
   })
   default = {}

--- a/modules/logging-infrastructure/variables.tf
+++ b/modules/logging-infrastructure/variables.tf
@@ -56,3 +56,12 @@ variable "labels" {
   description = "Labels to apply to resources"
   default     = {}
 }
+
+variable "pii_redaction" {
+  description = "PII redaction configuration using a Pub/Sub message transform (SMT) applied to the topic. When enabled, a JavaScript UDF redacts email addresses from BigQuery SQL query fields before messages are stored in the subscription backlog."
+  type = object({
+    enabled     = optional(bool, false)
+    custom_code = optional(string, null)
+  })
+  default = {}
+}

--- a/modules/logging-infrastructure/versions.tf
+++ b/modules/logging-infrastructure/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.13.0"
+      version = ">= 6.39.0"
     }
   }
 }

--- a/scripts/generate-moved-blocks.sh
+++ b/scripts/generate-moved-blocks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script to generate Terraform 'moved' blocks for migrating from v0.2.x to v0.3.0
+# Script to generate Terraform 'moved' blocks for migrating from v0.2.x to v0.3.0+
 # This helps avoid resource recreation during the module restructuring
 #
 # Usage: ./generate-moved-blocks.sh [MODULE_PREFIX]
@@ -54,7 +54,7 @@ fi
 
 # Initialize output file
 cat > "$OUTPUT_FILE" << 'EOF'
-# Generated moved blocks for v0.2.x to v0.3.0 migration
+# Generated moved blocks for v0.2.x to v0.3.0+ migration
 # This file helps preserve existing resources during module restructuring
 #
 # After applying these moved blocks:
@@ -78,11 +78,11 @@ if [ -z "$MODULES" ]; then
     exit 1
 fi
 
-# Check if state is already in v0.3.0 format (has logging_infrastructure)
+# Check if state is already in v0.3.0+ format (has logging_infrastructure)
 if echo "$MODULES" | grep -q "module.logging_infrastructure"; then
-    echo -e "${GREEN}✓ Your state appears to already be in v0.3.0 format!${NC}"
+    echo -e "${GREEN}✓ Your state appears to already be in v0.3.0+ format!${NC}"
     echo ""
-    echo "Detected logging_infrastructure module, which indicates you're already using v0.3.0."
+    echo "Detected logging_infrastructure module, which indicates you're already using v0.3.0+."
     echo "No migration needed - your resources are already in the correct structure."
     exit 0
 fi
@@ -444,7 +444,7 @@ echo -e "${GREEN}Success! Generated moved blocks in: $OUTPUT_FILE${NC}"
 echo ""
 echo "Next steps:"
 echo "1. Review the generated $OUTPUT_FILE"
-echo "2. Update your module source to v0.3.0"
+echo "2. Update your module source to v0.3.0+"
 echo "3. Run: terraform init -upgrade"
 echo "4. Run: terraform plan (should show moves, minimal recreations)"
 echo "5. Run: terraform apply"

--- a/variables.tf
+++ b/variables.tf
@@ -139,9 +139,8 @@ variable "labels" {
 }
 
 variable "pii_redaction" {
-  description = "PII redaction configuration for the BigQuery module. When enabled, a JavaScript UDF runs as a Pub/Sub message transform (SMT) on the BigQuery topic and redacts email addresses from SQL query fields in audit log entries."
+  description = "PII redaction configuration for the BigQuery module. Provide custom_code with a JavaScript UDF to enable a Pub/Sub message transform (SMT) on the BigQuery topic. The UDF runs at the topic level before messages reach the subscription backlog. The SMT is disabled when custom_code is null (default)."
   type = object({
-    enabled     = optional(bool, false)
     custom_code = optional(string, null)
   })
   default = {}

--- a/variables.tf
+++ b/variables.tf
@@ -138,3 +138,12 @@ variable "labels" {
   }
 }
 
+variable "pii_redaction" {
+  description = "PII redaction configuration for the BigQuery module. When enabled, a JavaScript UDF runs as a Pub/Sub message transform (SMT) on the BigQuery topic and redacts email addresses from SQL query fields in audit log entries."
+  type = object({
+    enabled     = optional(bool, false)
+    custom_code = optional(string, null)
+  })
+  default = {}
+}
+


### PR DESCRIPTION
This pull request introduces a new opt-in PII redaction feature for BigQuery logs using Pub/Sub SMT and updates documentation. The changes also refactor documentation for clarity and update module versions.

**New Feature: PII Redaction via Pub/Sub SMT**
- Added an optional `pii_redaction` variable to the BigQuery module. When enabled, a JavaScript UDF can redact email addresses from SQL query fields in BigQuery audit log entries before messages are stored in Pub/Sub. Users can provide a custom UDF or use the provided starter template.