### PR TITLE
feat: add create_organization_custom_roles variable, release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **BigQuery Log Sink**: Added missing `google.cloud.bigquery.v2.JobService.GetQueryResults` method to the BigQuery log sink filter
-
 ### Security
+
+## [0.4.0] - 2026-05-05
+
+### Added
+
+- **`create_organization_custom_roles` variable** (default `true`): in **folder mode**, allows opting out of org-level custom IAM role management. When set to `false`, the module skips creation of `mastheadBigQueryCustomRole` and `mastheadAnalyticsHubCustomRole` at the organization level and their folder-scope service account bindings — use this when an org administrator manages the roles out-of-band. The flag has no effect in project mode (project-level custom roles are always created since they don't require org-level permissions). Default behaviour is unchanged. See README → "Externally managed custom IAM roles" for the manual setup runbook.
+
+### Fixed
+
+- **BigQuery Log Sink**: Added missing `google.cloud.bigquery.v2.JobService.GetQueryResults` method to the BigQuery log sink filter
 
 ## [0.3.1] - 2026-04-07
 
@@ -208,7 +216,9 @@ module "masthead_agent" {
 - Dataform integration
 - Dataplex monitoring
 
-[Unreleased]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.2.10...v0.3.0
 [0.2.10]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.2.8...v0.2.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [0.4.0] - 2026-05-05
+## [0.4.0] - 2026-05-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`create_organization_custom_roles` variable** (default `true`): in **folder mode**, allows opting out of org-level custom IAM role management. When set to `false`, the module skips creation of `mastheadBigQueryCustomRole` and `mastheadAnalyticsHubCustomRole` at the organization level and their folder-scope service account bindings — use this when an org administrator manages the roles out-of-band. The flag has no effect in project mode (project-level custom roles are always created since they don't require org-level permissions). Default behaviour is unchanged. See README → "Externally managed custom IAM roles" for the manual setup runbook.
+- **`create_organization_custom_roles` variable** (default `true`): in **folder mode**, allows opting out of org-level custom IAM role management. Default behaviour is unchanged. See README → "Externally managed custom IAM roles" for the manual setup runbook.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ module "masthead_agent" {
 - `resourcemanager.projects.setIamPolicy`
 - `serviceusage.services.enable`
 
-**Each monitored folder**:
+**Each monitored folder** (when `monitored_folder_ids` is set):
 
 - `logging.sinks.create`
-- `resourcemanager.folders.setIamPolicy`
+- `resourcemanager.folders.setIamPolicy` (when  `create_organization_custom_roles = true`)
 
 **Organization level** (when `monitored_folder_ids` is set and `create_organization_custom_roles = true`):
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For single-project setups. All resources (logs, Pub/Sub, IAM) are created in a m
 ```hcl
 module "masthead_agent" {
   source  = "masthead-data/masthead-agent/google"
-  version = ">=0.3.1"
+  version = ">=0.4.0"
 
   # Project mode: single project
   project_id = "project-1"
@@ -54,7 +54,7 @@ For multi-project or folder-level monitoring. Creates centralized Pub/Sub infras
 ```hcl
 module "masthead_agent" {
   source  = "masthead-data/masthead-agent/google"
-  version = ">=0.3.1"
+  version = ">=0.4.0"
 
   # Organization mode: folders + additional projects
   monitored_folder_ids  = [
@@ -96,9 +96,55 @@ module "masthead_agent" {
 - `logging.sinks.create`
 - `resourcemanager.folders.setIamPolicy`
 
-**Organization level** (when `monitored_folder_ids` is set and `organization_id` is provided):
+**Organization level** (when `monitored_folder_ids` is set, `organization_id` is provided, and `create_organization_custom_roles = true`):
 
 - `iam.roles.create`
+
+### Externally managed custom IAM roles (folder mode only)
+
+By default the module creates two custom roles and binds them to the Masthead service account:
+
+- `mastheadBigQueryCustomRole` — `bigquery.datasets.listSharedDatasetUsage`
+- `mastheadAnalyticsHubCustomRole` — `analyticshub.listings.viewSubscriptions`
+
+In **folder mode** these roles are created at the organization scope, which requires `iam.roles.create` on the org. If your security policy forbids the deployment principal from holding that permission, set `create_organization_custom_roles = false`. The module then skips both the role definition and the SA binding for the two roles above; you are responsible for creating the roles at the organization level and granting them to the Masthead service account at folder scope.
+
+In **project mode** (`monitored_project_ids` only, no folders) the flag has no effect: the roles are project-level, scoped to the deployment project, and always created by the module.
+
+```hcl
+module "masthead_agent" {
+  source  = "masthead-data/masthead-agent/google"
+  version = ">=0.4.0"
+
+  monitored_folder_ids  = ["folders/111111111"]
+  deployment_project_id = "project-3"
+
+  create_organization_custom_roles = false  # org admin manages the custom roles manually
+}
+```
+
+Manual setup (run once, by an org admin):
+
+```bash
+gcloud iam roles create mastheadBigQueryCustomRole \
+  --organization=<ORG_ID> \
+  --title="Masthead BigQuery Custom Role" \
+  --permissions=bigquery.datasets.listSharedDatasetUsage
+
+gcloud iam roles create mastheadAnalyticsHubCustomRole \
+  --organization=<ORG_ID> \
+  --title="Masthead Analytics Hub Custom Role" \
+  --permissions=analyticshub.listings.viewSubscriptions
+
+# Grant each role to the Masthead BigQuery SA at the folder level (per monitored folder)
+gcloud resource-manager folders add-iam-policy-binding <FOLDER_ID> \
+  --member=serviceAccount:<MASTHEAD_BIGQUERY_SA> \
+  --role=organizations/<ORG_ID>/roles/mastheadBigQueryCustomRole
+
+gcloud resource-manager folders add-iam-policy-binding <FOLDER_ID> \
+  --member=serviceAccount:<MASTHEAD_BIGQUERY_SA> \
+  --role=organizations/<ORG_ID>/roles/mastheadAnalyticsHubCustomRole
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -96,10 +96,9 @@ module "masthead_agent" {
 - `logging.sinks.create`
 - `resourcemanager.folders.setIamPolicy`
 
-**Organization level** (when `monitored_folder_ids` is set, `organization_id` is provided, and `create_organization_custom_roles = true`):
+**Organization level** (when `monitored_folder_ids` is set and `create_organization_custom_roles = true`):
 
 - `iam.roles.create`
-
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -100,51 +100,6 @@ module "masthead_agent" {
 
 - `iam.roles.create`
 
-### Externally managed custom IAM roles (folder mode only)
-
-By default the module creates two custom roles and binds them to the Masthead service account:
-
-- `mastheadBigQueryCustomRole` — `bigquery.datasets.listSharedDatasetUsage`
-- `mastheadAnalyticsHubCustomRole` — `analyticshub.listings.viewSubscriptions`
-
-In **folder mode** these roles are created at the organization scope, which requires `iam.roles.create` on the org. If your security policy forbids the deployment principal from holding that permission, set `create_organization_custom_roles = false`. The module then skips both the role definition and the SA binding for the two roles above; you are responsible for creating the roles at the organization level and granting them to the Masthead service account at folder scope.
-
-In **project mode** (`monitored_project_ids` only, no folders) the flag has no effect: the roles are project-level, scoped to the deployment project, and always created by the module.
-
-```hcl
-module "masthead_agent" {
-  source  = "masthead-data/masthead-agent/google"
-  version = ">=0.4.0"
-
-  monitored_folder_ids  = ["folders/111111111"]
-  deployment_project_id = "project-3"
-
-  create_organization_custom_roles = false  # org admin manages the custom roles manually
-}
-```
-
-Manual setup (run once, by an org admin):
-
-```bash
-gcloud iam roles create mastheadBigQueryCustomRole \
-  --organization=<ORG_ID> \
-  --title="Masthead BigQuery Custom Role" \
-  --permissions=bigquery.datasets.listSharedDatasetUsage
-
-gcloud iam roles create mastheadAnalyticsHubCustomRole \
-  --organization=<ORG_ID> \
-  --title="Masthead Analytics Hub Custom Role" \
-  --permissions=analyticshub.listings.viewSubscriptions
-
-# Grant each role to the Masthead BigQuery SA at the folder level (per monitored folder)
-gcloud resource-manager folders add-iam-policy-binding <FOLDER_ID> \
-  --member=serviceAccount:<MASTHEAD_BIGQUERY_SA> \
-  --role=organizations/<ORG_ID>/roles/mastheadBigQueryCustomRole
-
-gcloud resource-manager folders add-iam-policy-binding <FOLDER_ID> \
-  --member=serviceAccount:<MASTHEAD_BIGQUERY_SA> \
-  --role=organizations/<ORG_ID>/roles/mastheadAnalyticsHubCustomRole
-```
 
 ## Documentation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,17 +110,9 @@ pii_redaction = {
 - The transform runs on the **topic**, so all subscribers automatically receive redacted messages.
 - Only applies to the BigQuery module. Other modules (Dataform, Dataplex) are unaffected.
 
+### Externally managed organization level custom IAM roles
 
-### Externally managed custom IAM roles (folder mode only)
-
-By default the module creates two custom roles and binds them to the Masthead service account:
-
-- `mastheadBigQueryCustomRole` — `bigquery.datasets.listSharedDatasetUsage`
-- `mastheadAnalyticsHubCustomRole` — `analyticshub.listings.viewSubscriptions`
-
-In **folder mode** these roles are created at the organization scope, which requires `iam.roles.create` on the org. If your security policy forbids the deployment principal from holding that permission, set `create_organization_custom_roles = false`. The module then skips both the role definition and the SA binding for the two roles above; you are responsible for creating the roles at the organization level and granting them to the Masthead service account at folder scope.
-
-In **project mode** (`monitored_project_ids` only, no folders) the flag has no effect: the roles are project-level, scoped to the deployment project, and always created by the module.
+Monitoring folders scope requires organization level custom roles. To apply such terraform configuration your Terraform pipeline must have `iam.roles.create` permission on the organization scope. If this is not the case, you can set `create_organization_custom_roles = false` to skip roles creation and the service account binding. In this case you are responsible for creating the identical roles at the organization level and granting them to the Masthead service account at folders scope.
 
 ```hcl
 module "masthead_agent" {
@@ -130,26 +122,26 @@ module "masthead_agent" {
   monitored_folder_ids  = ["folders/111111111"]
   deployment_project_id = "project-3"
 
-  create_organization_custom_roles = false  # org admin manages the custom roles manually
+  create_organization_custom_roles = false  # org admin manages the custom roles separate from this module
 }
 ```
 
-Manual setup (run once, by an org admin):
+Create roles and bind service accounts (example using gcloud):
 
 ```bash
 gcloud iam roles create mastheadCustomRole \
   --organization=<ORG_ID> \
   --title="Masthead Custom Role" \
-  --description="Permissions required by the Masthead agent (BigQuery shared dataset usage + Analytics Hub subscription viewing)" \
+  --description="Custom role required by the Masthead Data agent" \
   --permissions=bigquery.datasets.listSharedDatasetUsage,analyticshub.listings.viewSubscriptions
 
-# Grant the role to the Masthead BigQuery SA at the folder level (per monitored folder)
+# Run per each monitored folder
 gcloud resource-manager folders add-iam-policy-binding <FOLDER_ID> \
-  --member=serviceAccount:<MASTHEAD_BIGQUERY_SA> \
+  --member=serviceAccount:<MASTHEAD_SA> \
   --role=organizations/<ORG_ID>/roles/mastheadCustomRole
 ```
 
-Or, equivalently, as a standalone Terraform configuration. The module does not reference the role names when `create_organization_custom_roles = false`, so the two permissions can be combined into a single custom role for simpler administration. Apply this once with an org-admin principal that holds `iam.roles.create`; afterwards your main configuration can run with `create_organization_custom_roles = false` under a more restricted principal.
+Or, equivalently, as a standalone Terraform configuration:
 
 ```hcl
 variable "organization_id" {
@@ -162,9 +154,9 @@ variable "folder_ids" {
   description = "Folders where the Masthead service account should receive the custom role. Each entry can be 'folders/123456789' or just the numeric ID."
 }
 
-variable "masthead_bigquery_sa" {
+variable "masthead_sa" {
   type        = string
-  description = "Email of the Masthead BigQuery service account that the custom role is granted to."
+  description = "Email of the Masthead service account that the custom role is granted to."
   default     = "masthead-data@masthead-prod.iam.gserviceaccount.com"
 }
 
@@ -190,7 +182,7 @@ resource "google_folder_iam_member" "masthead_custom_role" {
 
   folder = each.value
   role   = google_organization_iam_custom_role.masthead.id
-  member = "serviceAccount:${var.masthead_bigquery_sa}"
+  member = "serviceAccount:${var.masthead_sa}"
 }
 ```
 
@@ -203,4 +195,3 @@ folder_ids = [
   "folders/222222222",
 ]
 ```
-

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,3 +109,98 @@ pii_redaction = {
 - The UDF must export a function named `redactPii(message, metadata)` matching the [Pub/Sub SMT UDF signature](https://docs.cloud.google.com/pubsub/docs/smts/udfs-overview).
 - The transform runs on the **topic**, so all subscribers automatically receive redacted messages.
 - Only applies to the BigQuery module. Other modules (Dataform, Dataplex) are unaffected.
+
+
+### Externally managed custom IAM roles (folder mode only)
+
+By default the module creates two custom roles and binds them to the Masthead service account:
+
+- `mastheadBigQueryCustomRole` — `bigquery.datasets.listSharedDatasetUsage`
+- `mastheadAnalyticsHubCustomRole` — `analyticshub.listings.viewSubscriptions`
+
+In **folder mode** these roles are created at the organization scope, which requires `iam.roles.create` on the org. If your security policy forbids the deployment principal from holding that permission, set `create_organization_custom_roles = false`. The module then skips both the role definition and the SA binding for the two roles above; you are responsible for creating the roles at the organization level and granting them to the Masthead service account at folder scope.
+
+In **project mode** (`monitored_project_ids` only, no folders) the flag has no effect: the roles are project-level, scoped to the deployment project, and always created by the module.
+
+```hcl
+module "masthead_agent" {
+  source  = "masthead-data/masthead-agent/google"
+  version = ">=0.4.0"
+
+  monitored_folder_ids  = ["folders/111111111"]
+  deployment_project_id = "project-3"
+
+  create_organization_custom_roles = false  # org admin manages the custom roles manually
+}
+```
+
+Manual setup (run once, by an org admin):
+
+```bash
+gcloud iam roles create mastheadCustomRole \
+  --organization=<ORG_ID> \
+  --title="Masthead Custom Role" \
+  --description="Permissions required by the Masthead agent (BigQuery shared dataset usage + Analytics Hub subscription viewing)" \
+  --permissions=bigquery.datasets.listSharedDatasetUsage,analyticshub.listings.viewSubscriptions
+
+# Grant the role to the Masthead BigQuery SA at the folder level (per monitored folder)
+gcloud resource-manager folders add-iam-policy-binding <FOLDER_ID> \
+  --member=serviceAccount:<MASTHEAD_BIGQUERY_SA> \
+  --role=organizations/<ORG_ID>/roles/mastheadCustomRole
+```
+
+Or, equivalently, as a standalone Terraform configuration. The module does not reference the role names when `create_organization_custom_roles = false`, so the two permissions can be combined into a single custom role for simpler administration. Apply this once with an org-admin principal that holds `iam.roles.create`; afterwards your main configuration can run with `create_organization_custom_roles = false` under a more restricted principal.
+
+```hcl
+variable "organization_id" {
+  type        = string
+  description = "GCP organization ID (numeric, no organizations/ prefix)."
+}
+
+variable "folder_ids" {
+  type        = list(string)
+  description = "Folders where the Masthead service account should receive the custom role. Each entry can be 'folders/123456789' or just the numeric ID."
+}
+
+variable "masthead_bigquery_sa" {
+  type        = string
+  description = "Email of the Masthead BigQuery service account that the custom role is granted to."
+  default     = "masthead-data@masthead-prod.iam.gserviceaccount.com"
+}
+
+variable "custom_role_id" {
+  type        = string
+  description = "Role ID for the combined Masthead custom role at the org level."
+  default     = "mastheadCustomRole"
+}
+
+resource "google_organization_iam_custom_role" "masthead" {
+  org_id      = var.organization_id
+  role_id     = var.custom_role_id
+  title       = "Masthead Custom Role"
+  description = "Permissions required by the Masthead agent (BigQuery shared dataset usage + Analytics Hub subscription viewing)"
+  permissions = [
+    "bigquery.datasets.listSharedDatasetUsage",
+    "analyticshub.listings.viewSubscriptions",
+  ]
+}
+
+resource "google_folder_iam_member" "masthead_custom_role" {
+  for_each = toset(var.folder_ids)
+
+  folder = each.value
+  role   = google_organization_iam_custom_role.masthead.id
+  member = "serviceAccount:${var.masthead_bigquery_sa}"
+}
+```
+
+Example `terraform.tfvars`:
+
+```hcl
+organization_id = "123456789"
+folder_ids = [
+  "folders/111111111",
+  "folders/222222222",
+]
+```
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ module "masthead_agent" {
   enable_apis                  = true
   enable_privatelogviewer_role = true  # For retrospective log export
   enable_datascan_editing      = false # Dataplex DataScan editing permissions
-  create_organization_custom_roles          = true  # Folder mode only: set to false if the org-level Masthead custom IAM roles are managed externally. No effect in project mode.
+  create_organization_custom_roles          = true  # Create the organization level custom roles (relevant only for monitored folders). Set to false if the organization level custom IAM roles are managed outside of this module.
 
   # PII redaction (optional) — provide a UDF to enable SMT on the BigQuery topic
   # See ## PII Redaction below for a ready-to-use email redaction example

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ Configuration example with all available options:
 ```hcl
 module "masthead_agent" {
   source  = "masthead-data/masthead-agent/google"
-  version = ">=0.3.1"
+  version = ">=0.4.0"
 
   # Choose ONE mode:
 
@@ -30,6 +30,7 @@ module "masthead_agent" {
   enable_apis                  = true
   enable_privatelogviewer_role = true  # For retrospective log export
   enable_datascan_editing      = false # Dataplex DataScan editing permissions
+  create_organization_custom_roles          = true  # Folder mode only: set to false if the org-level Masthead custom IAM roles are managed externally. No effect in project mode.
 
   # PII redaction (optional) — provide a UDF to enable SMT on the BigQuery topic
   # See ## PII Redaction below for a ready-to-use email redaction example

--- a/examples/org-mode.tfvars.example
+++ b/examples/org-mode.tfvars.example
@@ -32,11 +32,8 @@ enable_privatelogviewer_role = true
 enable_apis                  = true
 enable_datascan_editing      = false
 
-# Set to false if an organization administrator manages the Masthead custom IAM
-# roles (mastheadBigQueryCustomRole, mastheadAnalyticsHubCustomRole) at the org
-# level and grants them to the Masthead service account out-of-band. When false,
-# organization_id is no longer required. Default: true.
-# create_organization_custom_roles = false
+# Create the organization level custom roles (relevant only for monitored folders). Set to false if the organization level custom IAM roles are managed outside of this module.
+create_organization_custom_roles = true
 
 # Labels
 labels = {

--- a/examples/org-mode.tfvars.example
+++ b/examples/org-mode.tfvars.example
@@ -32,6 +32,12 @@ enable_privatelogviewer_role = true
 enable_apis                  = true
 enable_datascan_editing      = false
 
+# Set to false if an organization administrator manages the Masthead custom IAM
+# roles (mastheadBigQueryCustomRole, mastheadAnalyticsHubCustomRole) at the org
+# level and grants them to the Masthead service account out-of-band. When false,
+# organization_id is no longer required. Default: true.
+# create_organization_custom_roles = false
+
 # Labels
 labels = {
   service     = "masthead-agent"

--- a/examples/pulumi-script/Pulumi.yaml
+++ b/examples/pulumi-script/Pulumi.yaml
@@ -11,5 +11,5 @@ packages:
     version: 0.1.8
     parameters:
       - masthead-data/masthead-agent/google
-      - 0.3.1
+      - 0.4.0
       - masthead-agent

--- a/examples/pulumi-script/README.md
+++ b/examples/pulumi-script/README.md
@@ -14,14 +14,14 @@ Install Pulumi CLI:
 
 1. Install required Python packages:
 
-    ```bash
-    pulumi package add terraform-module masthead-data/masthead-agent/google [VERSION] masthead-agent
-    ```
+        ```bash
+        pulumi package add terraform-module masthead-data/masthead-agent/google [VERSION] masthead-agent
+        ```
 
 2. Configure Masthead Agent stack - [see example](./__main__.py) for reference.
 
 3. Preview Pulumi project resources:
 
-    ```bash
-    pulumi preview
-    ```
+        ```bash
+        pulumi preview
+        ```

--- a/main.tf
+++ b/main.tf
@@ -31,8 +31,8 @@ resource "null_resource" "validate_configuration" {
     }
 
     precondition {
-      condition     = !local.has_folders || var.organization_id != null
-      error_message = "organization_id is required when using monitored_folder_ids to create organization-level custom IAM roles."
+      condition     = !var.create_organization_custom_roles || !local.has_folders || var.organization_id != null
+      error_message = "organization_id is required when using monitored_folder_ids with create_organization_custom_roles=true. Set create_organization_custom_roles=false if the custom roles are managed externally at the organization level."
     }
   }
 }
@@ -49,8 +49,9 @@ module "bigquery" {
   organization_id       = local.numeric_organization_id
 
   # Service account and permissions
-  masthead_service_accounts    = var.masthead_service_accounts
-  enable_privatelogviewer_role = var.enable_privatelogviewer_role
+  masthead_service_accounts        = var.masthead_service_accounts
+  enable_privatelogviewer_role     = var.enable_privatelogviewer_role
+  create_organization_custom_roles = var.create_organization_custom_roles
 
   # Resource configuration
   enable_apis   = var.enable_apis
@@ -106,7 +107,8 @@ module "analytics_hub" {
   monitored_project_ids = local.all_monitored_projects
 
   # Service account
-  masthead_service_accounts = var.masthead_service_accounts
+  masthead_service_accounts        = var.masthead_service_accounts
+  create_organization_custom_roles = var.create_organization_custom_roles
 
   # Resource configuration
   enable_apis = var.enable_apis

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "null_resource" "validate_configuration" {
 
     precondition {
       condition     = !var.create_organization_custom_roles || !local.has_folders || var.organization_id != null
-      error_message = "organization_id is required when using monitored_folder_ids with create_organization_custom_roles=true. Set create_organization_custom_roles=false if the custom roles are managed externally at the organization level."
+      error_message = "organization_id is required when using monitored_folder_ids with create_organization_custom_roles=true."
     }
   }
 }

--- a/modules/analytics-hub/README.md
+++ b/modules/analytics-hub/README.md
@@ -5,3 +5,10 @@ This module sets up the necessary infrastructure for Masthead Data to monitor An
 ## Resources Created
 
 - **IAM Bindings**: Grants necessary permissions to Masthead service accounts
+- **Custom IAM Role**: Grants `analyticshub.listings.viewSubscriptions` permission
+  - Organization-level role for folder monitoring (requires `organization_id`); gated by `create_organization_custom_roles`.
+  - Project-level role for project mode.
+
+## Requirements
+
+- **Organization Mode**: `organization_id` must be provided to create the organization-level custom IAM role.

--- a/modules/analytics-hub/main.tf
+++ b/modules/analytics-hub/main.tf
@@ -22,7 +22,7 @@ resource "google_project_service" "analyticshub_api" {
 
 # Custom role for Analytics Hub subscription viewing at folder level
 resource "google_organization_iam_custom_role" "analyticshub_custom_role_folder" {
-  count = local.has_folders && var.organization_id != null ? 1 : 0
+  count = var.create_organization_custom_roles && local.has_folders && var.organization_id != null ? 1 : 0
 
   org_id      = var.organization_id
   role_id     = "mastheadAnalyticsHubCustomRole"
@@ -68,7 +68,7 @@ resource "google_folder_iam_member" "masthead_analyticshub_folder_roles" {
 
 # IAM: Grant custom role at folder level
 resource "google_folder_iam_member" "masthead_analyticshub_folder_custom_role" {
-  for_each = local.has_folders && var.organization_id != null ? toset(var.monitored_folder_ids) : toset([])
+  for_each = var.create_organization_custom_roles && local.has_folders && var.organization_id != null ? toset(var.monitored_folder_ids) : toset([])
 
   folder = each.value
   role   = google_organization_iam_custom_role.analyticshub_custom_role_folder[0].id

--- a/modules/analytics-hub/variables.tf
+++ b/modules/analytics-hub/variables.tf
@@ -31,6 +31,6 @@ variable "enable_apis" {
 
 variable "create_organization_custom_roles" {
   type        = bool
-  description = "Whether to create the org-level custom roles."
+  description = "Create the organization level custom roles (relevant only for monitored folders). Set to false if the organization level custom IAM roles are managed outside of this module."
   default     = true
 }

--- a/modules/analytics-hub/variables.tf
+++ b/modules/analytics-hub/variables.tf
@@ -28,3 +28,9 @@ variable "enable_apis" {
   description = "Enable required Google Cloud APIs"
   default     = true
 }
+
+variable "create_organization_custom_roles" {
+  type        = bool
+  description = "Whether to create the org-level custom roles."
+  default     = true
+}

--- a/modules/bigquery/README.md
+++ b/modules/bigquery/README.md
@@ -9,9 +9,9 @@ This module sets up the necessary infrastructure for Masthead Data to monitor Bi
 - **Cloud Logging Sink**: Routes BigQuery audit logs to Pub/Sub
 - **IAM Bindings**: Grants necessary permissions to Masthead service accounts
 - **Custom IAM Role**: Grants `bigquery.datasets.listSharedDatasetUsage` permission
-  - Organization-level role for folder monitoring (requires `organization_id`); gated by `create_organization_custom_roles` (default `true`). Set to `false` to manage the org-level role and binding externally.
-  - Project-level role for project mode; always created (not affected by `create_organization_custom_roles`).
+  - Organization-level role for folder monitoring (requires `organization_id`); gated by `create_organization_custom_roles`.
+  - Project-level role for project mode.
 
 ## Requirements
 
-- **Organization Mode** with `create_organization_custom_roles = true`: `organization_id` must be provided to create the organization-level custom IAM role.
+- **Organization Mode**: `organization_id` must be provided to create the organization-level custom IAM role.

--- a/modules/bigquery/README.md
+++ b/modules/bigquery/README.md
@@ -9,9 +9,9 @@ This module sets up the necessary infrastructure for Masthead Data to monitor Bi
 - **Cloud Logging Sink**: Routes BigQuery audit logs to Pub/Sub
 - **IAM Bindings**: Grants necessary permissions to Masthead service accounts
 - **Custom IAM Role**: Grants `bigquery.datasets.listSharedDatasetUsage` permission
-  - Organization-level role for folder monitoring (requires `organization_id`)
-  - Project-level role for project mode
+  - Organization-level role for folder monitoring (requires `organization_id`); gated by `create_organization_custom_roles` (default `true`). Set to `false` to manage the org-level role and binding externally.
+  - Project-level role for project mode; always created (not affected by `create_organization_custom_roles`).
 
 ## Requirements
 
-- **Organization Mode**: `organization_id` must be provided to create organization-level custom IAM role
+- **Organization Mode** with `create_organization_custom_roles = true`: `organization_id` must be provided to create the organization-level custom IAM role.

--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -124,7 +124,7 @@ resource "google_project_iam_member" "masthead_privatelogviewer_project_role" {
 
 # Custom role for BigQuery shared dataset usage at organization level
 resource "google_organization_iam_custom_role" "masthead_bigquery_custom_role_folder" {
-  count = local.has_folders && var.organization_id != null ? 1 : 0
+  count = var.create_organization_custom_roles && local.has_folders && var.organization_id != null ? 1 : 0
 
   org_id      = var.organization_id
   role_id     = "mastheadBigQueryCustomRole"
@@ -150,7 +150,7 @@ resource "google_project_iam_custom_role" "masthead_bigquery_custom_role_project
 
 # IAM: Grant custom role at folder level
 resource "google_folder_iam_member" "masthead_bigquery_folder_custom_role" {
-  for_each = local.has_folders && var.organization_id != null ? toset(var.monitored_folder_ids) : toset([])
+  for_each = var.create_organization_custom_roles && local.has_folders && var.organization_id != null ? toset(var.monitored_folder_ids) : toset([])
 
   folder = each.value
   role   = google_organization_iam_custom_role.masthead_bigquery_custom_role_folder[0].id

--- a/modules/bigquery/variables.tf
+++ b/modules/bigquery/variables.tf
@@ -37,7 +37,7 @@ variable "enable_privatelogviewer_role" {
 
 variable "create_organization_custom_roles" {
   type        = bool
-  description = "Whether to create the org-level mastheadBigQueryCustomRole and bind it to the Masthead BigQuery service account. Only applies in folder mode; in project mode the project-level custom role is always created. Set to false when the org-level role and binding are managed externally."
+  description = "Create the organization level custom roles (relevant only for monitored folders). Set to false if the organization level custom IAM roles are managed outside of this module."
   default     = true
 }
 

--- a/modules/bigquery/variables.tf
+++ b/modules/bigquery/variables.tf
@@ -35,6 +35,12 @@ variable "enable_privatelogviewer_role" {
   default     = true
 }
 
+variable "create_organization_custom_roles" {
+  type        = bool
+  description = "Whether to create the org-level mastheadBigQueryCustomRole and bind it to the Masthead BigQuery service account. Only applies in folder mode; in project mode the project-level custom role is always created. Set to false when the org-level role and binding are managed externally."
+  default     = true
+}
+
 variable "enable_apis" {
   type        = bool
   description = "Enable required Google Cloud APIs"

--- a/variables.tf
+++ b/variables.tf
@@ -130,10 +130,6 @@ variable "create_organization_custom_roles" {
     In project mode (monitored_project_ids only) this flag has no effect: the module always creates the
     project-level custom roles, since they are scoped to the deployment project and don't require org-level
     permissions.
-
-    When false (folder mode only), the module skips both role creation and the SA binding for:
-      - mastheadBigQueryCustomRole       (permission: bigquery.datasets.listSharedDatasetUsage)
-      - mastheadAnalyticsHubCustomRole   (permission: analyticshub.listings.viewSubscriptions)
   EOT
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -121,15 +121,7 @@ variable "enable_privatelogviewer_role" {
 variable "create_organization_custom_roles" {
   type        = bool
   description = <<-EOT
-    Whether this module creates the Masthead custom IAM roles and binds them to the Masthead service account.
-    Only applies in folder/organization mode (when monitored_folder_ids is set), where the roles must be
-    created at the organization scope and the deploying principal therefore needs iam.roles.create on the org.
-    Set to false when an organization administrator will create the org-level custom roles and grant them
-    to the Masthead service account out-of-band (e.g. via gcloud or console).
-
-    In project mode (monitored_project_ids only) this flag has no effect: the module always creates the
-    project-level custom roles, since they are scoped to the deployment project and don't require org-level
-    permissions.
+    Create the organization level custom roles (relevant only for monitored folders). Set to false if the organization level custom IAM roles are managed outside of this module.
   EOT
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -118,6 +118,26 @@ variable "enable_privatelogviewer_role" {
   default     = true
 }
 
+variable "create_organization_custom_roles" {
+  type        = bool
+  description = <<-EOT
+    Whether this module creates the Masthead custom IAM roles and binds them to the Masthead service account.
+    Only applies in folder/organization mode (when monitored_folder_ids is set), where the roles must be
+    created at the organization scope and the deploying principal therefore needs iam.roles.create on the org.
+    Set to false when an organization administrator will create the org-level custom roles and grant them
+    to the Masthead service account out-of-band (e.g. via gcloud or console).
+
+    In project mode (monitored_project_ids only) this flag has no effect: the module always creates the
+    project-level custom roles, since they are scoped to the deployment project and don't require org-level
+    permissions.
+
+    When false (folder mode only), the module skips both role creation and the SA binding for:
+      - mastheadBigQueryCustomRole       (permission: bigquery.datasets.listSharedDatasetUsage)
+      - mastheadAnalyticsHubCustomRole   (permission: analyticshub.listings.viewSubscriptions)
+  EOT
+  default     = true
+}
+
 variable "enable_apis" {
   type        = bool
   description = "Enable required Google Cloud APIs in all modules"


### PR DESCRIPTION
Allows opting out of the module's org-level Masthead custom IAM role management when deploying in folder mode. When set to false, the module skips creation of mastheadBigQueryCustomRole and mastheadAnalyticsHubCustomRole at the organization scope and their folder-level service account bindings, so an organization administrator can manage them out-of-band. Required for environments where the Terraform deployment principal cannot hold iam.roles.create on the organization.

The flag has no effect in project mode: project-level custom roles are scoped to the deployment project and do not require org-level permissions, so they are always created. The precondition that requires organization_id in folder mode is relaxed when the flag is false.

Default is true, preserving current behavior.

Bumps module version to 0.4.0 and updates example version pins in README and docs/configuration.md. Adds a runbook in README for the manual gcloud setup of the externally-managed roles, and backfills the missing v0.3.1 link footer in CHANGELOG.