### PR TITLE
Add DeleteTable method to BigQuery permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **BigQuery Log Sink**: Added `google.cloud.bigquery.v2.TableService.DeleteTable` method to the BigQuery log sink filter
+- **BigQuery Log Sink**: Added `google.cloud.bigquery.v2.TableService.DeleteTable` and `google.cloud.bigquery.storage.v1.BigQueryRead.CreateReadSession` methods to the BigQuery log sink filter
 
 ### Changed
 
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- **BigQuery Log Sink**: Corrected `google.cloud.bigquery.storage.v1.BigQueryRead.ReadRows` method in the BigQuery log sink filter (was incorrectly under `BigQueryWrite`)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **BigQuery Log Sink**: Added `google.cloud.bigquery.v2.TableService.DeleteTable` method to the BigQuery log sink filter
+
 ### Changed
 
 - **Combinatorial Resource Generation**: Replaced nested `flatten` loops and `split()` calls with `setproduct` map iteration and `toset()` deduplication across all modules

--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -22,7 +22,8 @@ locals {
   protoPayload.methodName="google.cloud.bigquery.v2.JobService.InsertJob" OR
   protoPayload.methodName="google.cloud.bigquery.v2.JobService.Query" OR
   protoPayload.methodName="google.cloud.bigquery.v2.TableDataService.List" OR
-  protoPayload.methodName="google.cloud.bigquery.v2.TableService.InsertTable"
+  protoPayload.methodName="google.cloud.bigquery.v2.TableService.InsertTable" OR
+  protoPayload.methodName="google.cloud.bigquery.v2.TableService.DeleteTable"
 ) AND (
   resource.type="bigquery_table" OR
   resource.type="bigquery_dataset" OR

--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -16,14 +16,15 @@ locals {
   # Log filter for BigQuery monitoring
   bigquery_log_filter = <<-EOT
 (
+  protoPayload.methodName="google.cloud.bigquery.storage.v1.BigQueryRead.CreateReadSession" OR
+  protoPayload.methodName="google.cloud.bigquery.storage.v1.BigQueryRead.ReadRows" OR
   protoPayload.methodName="google.cloud.bigquery.storage.v1.BigQueryWrite.AppendRows" OR
-  protoPayload.methodName="google.cloud.bigquery.storage.v1.BigQueryWrite.ReadRows" OR
   protoPayload.methodName="google.cloud.bigquery.v2.JobService.GetQueryResults" OR
   protoPayload.methodName="google.cloud.bigquery.v2.JobService.InsertJob" OR
   protoPayload.methodName="google.cloud.bigquery.v2.JobService.Query" OR
   protoPayload.methodName="google.cloud.bigquery.v2.TableDataService.List" OR
-  protoPayload.methodName="google.cloud.bigquery.v2.TableService.InsertTable" OR
-  protoPayload.methodName="google.cloud.bigquery.v2.TableService.DeleteTable"
+  protoPayload.methodName="google.cloud.bigquery.v2.TableService.DeleteTable" OR
+  protoPayload.methodName="google.cloud.bigquery.v2.TableService.InsertTable"
 ) AND (
   resource.type="bigquery_table" OR
   resource.type="bigquery_dataset" OR


### PR DESCRIPTION
TODO:
1. review the following:
```
protoPayload.methodName="google.cloud.bigquery.storage.v1.BigQueryWrite.AppendRows"
protoPayload.methodName="google.cloud.bigquery.storage.v1.BigQueryRead.CreateReadSession"
protoPayload.methodName="google.cloud.bigquery.storage.v1.BigQueryRead.ReadRows"
protoPayload.methodName="google.cloud.bigquery.v2.TableService.DeleteTable"
protoPayload.methodName="google.cloud.bigquery.v2.TableService.InsertTable"
```