### PR TITLE
Update IAM documentation, 'bigquery.config.get' and 'roles/dataplex.storageDataReader' permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.4.2] - 2026-06-08
+
+### Added
+
+- **BigQuery Custom Role**: Added `bigquery.config.get` permission to the `mastheadBigQueryCustomRole` custom IAM role (both organization-level and project-level variants) to allow reading BigQuery project-level configuration settings
+- **Dataplex IAM**: Restored `roles/dataplex.storageDataReader` to Dataplex service account permissions, gated by `enable_datascan_editing = true`, to allow editing datascans
+
 ## [0.4.1] - 2026-05-11
 
 ### Added
@@ -222,7 +229,8 @@ module "masthead_agent" {
 - Dataform integration
 - Dataplex monitoring
 
-[Unreleased]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/masthead-data/terraform-google-masthead-agent/compare/v0.3.0...v0.3.1

--- a/modules/analytics-hub/README.md
+++ b/modules/analytics-hub/README.md
@@ -4,10 +4,11 @@ This module sets up the necessary infrastructure for Masthead Data to monitor An
 
 ## Resources Created
 
-- **IAM Bindings**: Grants necessary permissions to Masthead service accounts
-- **Custom IAM Role**: Grants `analyticshub.listings.viewSubscriptions` permission
-  - Organization-level role for folder monitoring (requires `organization_id`); gated by `create_organization_custom_roles`.
-  - Project-level role for project mode.
+- **IAM Bindings**: Grants the following roles to Masthead service accounts:
+  - `roles/analyticshub.viewer` — Read-only access to Analytics Hub resources
+  - `mastheadAnalyticsHubCustomRole` (custom) — See **Custom IAM Role** below
+- **Custom IAM Role**: Grants the following custom permissions:
+  - `analyticshub.listings.viewSubscriptions` — View subscriptions for Analytics Hub listings
 
 ## Requirements
 

--- a/modules/bigquery/README.md
+++ b/modules/bigquery/README.md
@@ -7,10 +7,15 @@ This module sets up the necessary infrastructure for Masthead Data to monitor Bi
 - **Pub/Sub Topic**: Receives BigQuery audit logs
 - **Pub/Sub Subscription**: Allows Masthead agents to consume audit logs
 - **Cloud Logging Sink**: Routes BigQuery audit logs to Pub/Sub
-- **IAM Bindings**: Grants necessary permissions to Masthead service accounts
-- **Custom IAM Role**: Grants `bigquery.datasets.listSharedDatasetUsage` permission
-  - Organization-level role for folder monitoring (requires `organization_id`); gated by `create_organization_custom_roles`.
-  - Project-level role for project mode.
+- **IAM Bindings**: Grants the following roles to Masthead service accounts:
+  - `roles/bigquery.metadataViewer` — Read metadata of BigQuery resources
+  - `roles/bigquery.resourceViewer` — View BigQuery resource configurations
+  - `roles/resourcemanager.folderViewer` — View folder hierarchy _(folder mode only)_
+  - `roles/logging.privateLogViewer` — Read private log entries _(only when `enable_privatelogviewer_role = true`)_
+  - `mastheadBigQueryCustomRole` (custom) — See **Custom IAM Role** below
+- **Custom IAM Role**: Grants the following custom permissions:
+  - `bigquery.config.get` — Read BigQuery project-level configuration settings
+  - `bigquery.datasets.listSharedDatasetUsage` — List shared dataset usage across projects
 
 ## Requirements
 

--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -131,6 +131,7 @@ resource "google_organization_iam_custom_role" "masthead_bigquery_custom_role_fo
   title       = "Masthead BigQuery Custom Role"
   description = "Custom role for Masthead BigQuery agent"
   permissions = [
+    "bigquery.config.get",
     "bigquery.datasets.listSharedDatasetUsage"
   ]
 }
@@ -144,6 +145,7 @@ resource "google_project_iam_custom_role" "masthead_bigquery_custom_role_project
   title       = "Masthead BigQuery Custom Role"
   description = "Custom role for Masthead BigQuery agent"
   permissions = [
+    "bigquery.config.get",
     "bigquery.datasets.listSharedDatasetUsage"
   ]
 }

--- a/modules/dataform/README.md
+++ b/modules/dataform/README.md
@@ -7,4 +7,5 @@ This module sets up the necessary infrastructure for Masthead Data to monitor Da
 - **Pub/Sub Topic**: Receives Dataform audit logs
 - **Pub/Sub Subscription**: Allows Masthead agents to consume audit logs
 - **Cloud Logging Sink**: Routes Dataform audit logs to Pub/Sub
-- **IAM Bindings**: Grants necessary permissions to Masthead service accounts
+- **IAM Bindings**: Grants the following predefined roles to Masthead service accounts:
+  - `roles/dataform.viewer` — Read-only access to Dataform repositories and workflow invocations

--- a/modules/dataplex/README.md
+++ b/modules/dataplex/README.md
@@ -7,4 +7,9 @@ This module sets up the necessary infrastructure for Masthead Data to monitor Da
 - **Pub/Sub Topic**: Receives Dataplex audit logs
 - **Pub/Sub Subscription**: Allows Masthead agents to consume audit logs
 - **Cloud Logging Sink**: Routes Dataplex audit logs to Pub/Sub
-- **IAM Bindings**: Grants necessary permissions to Masthead service accounts
+- **IAM Bindings**: Grants the following predefined roles to Masthead service accounts:
+  - `roles/dataplex.dataProductsViewer` — View Dataplex data products
+  - `roles/dataplex.dataScanDataViewer` — View data scan results and profiles
+  - `roles/dataplex.dataScanEditor` — Create and manage data scans _(only when `enable_datascan_editing = true`)_
+  - `roles/dataplex.storageDataReader` — Read underlying Cloud Storage data for datascan execution _(only when `enable_datascan_editing = true`)_
+  - `roles/bigquery.jobUser` — Run BigQuery jobs for datascan execution _(only when `enable_datascan_editing = true`)_

--- a/modules/dataplex/main.tf
+++ b/modules/dataplex/main.tf
@@ -37,6 +37,7 @@ EOT
     "roles/dataplex.dataProductsViewer",
     "roles/dataplex.dataScanDataViewer",
     "roles/dataplex.dataScanEditor",
+    "roles/dataplex.storageDataReader",
     "roles/bigquery.jobUser"
     ]) : toset([
     "roles/dataplex.dataProductsViewer",


### PR DESCRIPTION
This pull request introduces updates for version 0.4.2, focusing on expanding IAM permissions and improving documentation for the Masthead Data Terraform modules. The main enhancements include adding new permissions to custom roles for BigQuery and Dataplex, as well as clarifying the IAM roles and permissions granted by each module in their respective README files.

**BigQuery Module Enhancements:**
- Added the `bigquery.config.get` permission to both the organization-level and project-level `mastheadBigQueryCustomRole` to allow reading project-level configuration settings.
- Updated the README to detail all roles (predefined and custom) granted to Masthead service accounts, including the new permission.

**Dataplex Module Enhancements:**
- Restored the `roles/dataplex.storageDataReader` permission (gated by `enable_datascan_editing = true`) to allow Dataplex service accounts to read underlying storage for datascan execution.
- Updated the README to clearly list all IAM roles, including conditional roles based on the `enable_datascan_editing` flag.

**Documentation Improvements Across Modules:**
- Improved IAM bindings and permissions documentation in the READMEs for BigQuery, Analytics Hub, Dataform, and Dataplex modules to clearly specify which roles and permissions are granted, including distinctions between predefined and custom roles.

**Changelog and Versioning:**
- Added a new section for version 0.4.2 in `CHANGELOG.md` documenting the above permission changes and updates.
- Updated release links at the bottom of the changelog to reference v0.4.2.