### PR TITLE
fix: apply project-level IAM in mixed folder + project deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BigQuery Custom Role**: Added `bigquery.config.get` permission to the `mastheadBigQueryCustomRole` custom IAM role (both organization-level and project-level variants) to allow reading BigQuery project-level configuration settings
 - **Dataplex IAM**: Restored `roles/dataplex.storageDataReader` to Dataplex service account permissions, gated by `enable_datascan_editing = true`, to allow editing datascans
 
+### Fixed
+
+- **Mixed folder + project deployments**: Project-level IAM bindings for projects listed in `monitored_project_ids` were silently skipped whenever any `monitored_folder_ids` were also set. The modules treated folder and project monitoring as mutually exclusive (`iam_target_projects = local.has_folders ? [] : var.monitored_project_ids`), so standalone projects outside the monitored folders lost their grants on apply — including Private Log Viewer (`roles/logging.privateLogViewer`) for the retro service account and BigQuery `metadataViewer`/`resourceViewer` (INFORMATION_SCHEMA timelines access). Project-level IAM is now always applied to the explicitly listed `monitored_project_ids`, independent of folder monitoring, across the `bigquery`, `analytics-hub`, `dataplex`, and `dataform` modules.
+
 ## [0.4.1] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For single-project setups. All resources (logs, Pub/Sub, IAM) are created in a m
 ```hcl
 module "masthead_agent" {
   source  = "masthead-data/masthead-agent/google"
-  version = ">=0.4.1"
+  version = ">=0.4.2"
 
   # Project mode: single project
   project_id = "project-1"
@@ -54,7 +54,7 @@ For multi-project or folder-level monitoring. Creates centralized Pub/Sub infras
 ```hcl
 module "masthead_agent" {
   source  = "masthead-data/masthead-agent/google"
-  version = ">=0.4.1"
+  version = ">=0.4.2"
 
   # Organization mode: folders + additional projects
   monitored_folder_ids  = [

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ Configuration example with all available options:
 ```hcl
 module "masthead_agent" {
   source  = "masthead-data/masthead-agent/google"
-  version = ">=0.4.1"
+  version = ">=0.4.2"
 
   # Choose ONE mode:
 
@@ -117,7 +117,7 @@ Monitoring folders scope requires organization level custom roles. To apply such
 ```hcl
 module "masthead_agent" {
   source  = "masthead-data/masthead-agent/google"
-  version = ">=0.4.1"
+  version = ">=0.4.2"
 
   monitored_folder_ids  = ["folders/111111111"]
   deployment_project_id = "project-3"

--- a/examples/pulumi-script/Pulumi.yaml
+++ b/examples/pulumi-script/Pulumi.yaml
@@ -11,5 +11,5 @@ packages:
     version: 0.1.8
     parameters:
       - masthead-data/masthead-agent/google
-      - 0.4.1
+      - 0.4.2
       - masthead-agent

--- a/modules/analytics-hub/main.tf
+++ b/modules/analytics-hub/main.tf
@@ -5,8 +5,9 @@ locals {
   # Determine if we're operating at folder or project level
   has_folders = length(var.monitored_folder_ids) > 0
 
-  # Projects where IAM bindings need to be applied (only when not using folders)
-  iam_target_projects = local.has_folders ? [] : var.monitored_project_ids
+  # Explicitly listed standalone projects always need project-level IAM bindings,
+  # independent of whether folders are also monitored (they live outside the folders).
+  iam_target_projects = var.monitored_project_ids
 }
 
 # Enable Analytics Hub API in monitored projects
@@ -35,7 +36,7 @@ resource "google_organization_iam_custom_role" "analyticshub_custom_role_folder"
 
 # Custom role for Analytics Hub subscription viewing at project level
 resource "google_project_iam_custom_role" "analyticshub_custom_role_project" {
-  for_each = !local.has_folders ? toset(local.iam_target_projects) : toset([])
+  for_each = toset(local.iam_target_projects)
 
   project     = each.value
   role_id     = "mastheadAnalyticsHubCustomRole"

--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -33,8 +33,9 @@ EOT
   # Determine if we're operating at folder or project level
   has_folders = length(var.monitored_folder_ids) > 0
 
-  # Projects where IAM bindings need to be applied (only when not using folders)
-  iam_target_projects = local.has_folders ? [] : var.monitored_project_ids
+  # Explicitly listed standalone projects always need project-level IAM bindings,
+  # independent of whether folders are also monitored (they live outside the folders).
+  iam_target_projects = var.monitored_project_ids
 }
 
 # Enable BigQuery API in monitored projects
@@ -115,7 +116,7 @@ resource "google_folder_iam_member" "masthead_privatelogviewer_folder_role" {
 
 # IAM: Grant Masthead retro service account Private Log Viewer role at project level
 resource "google_project_iam_member" "masthead_privatelogviewer_project_role" {
-  for_each = var.enable_privatelogviewer_role && !local.has_folders ? toset(local.iam_target_projects) : toset([])
+  for_each = var.enable_privatelogviewer_role ? toset(local.iam_target_projects) : toset([])
 
   project = each.value
   role    = "roles/logging.privateLogViewer"
@@ -138,7 +139,7 @@ resource "google_organization_iam_custom_role" "masthead_bigquery_custom_role_fo
 
 # Custom role for BigQuery shared dataset usage at project level
 resource "google_project_iam_custom_role" "masthead_bigquery_custom_role_project" {
-  for_each = !local.has_folders ? toset(local.iam_target_projects) : toset([])
+  for_each = toset(local.iam_target_projects)
 
   project     = each.value
   role_id     = "mastheadBigQueryCustomRole"
@@ -161,7 +162,7 @@ resource "google_folder_iam_member" "masthead_bigquery_folder_custom_role" {
 
 # IAM: Grant custom role at project level
 resource "google_project_iam_member" "masthead_bigquery_project_custom_role" {
-  for_each = !local.has_folders ? toset(local.iam_target_projects) : toset([])
+  for_each = toset(local.iam_target_projects)
 
   project = each.value
   role    = google_project_iam_custom_role.masthead_bigquery_custom_role_project[each.value].id

--- a/modules/dataform/main.tf
+++ b/modules/dataform/main.tf
@@ -24,8 +24,9 @@ EOT
   # Determine if we're operating at folder or project level
   has_folders = length(var.monitored_folder_ids) > 0
 
-  # Projects where IAM bindings need to be applied (only when not using folders)
-  iam_target_projects = local.has_folders ? [] : var.monitored_project_ids
+  # Explicitly listed standalone projects always need project-level IAM bindings,
+  # independent of whether folders are also monitored (they live outside the folders).
+  iam_target_projects = var.monitored_project_ids
 }
 
 # Enable Dataform API in monitored projects

--- a/modules/dataplex/main.tf
+++ b/modules/dataplex/main.tf
@@ -29,8 +29,9 @@ EOT
   # Determine if we're operating at folder or project level
   has_folders = length(var.monitored_folder_ids) > 0
 
-  # Projects where IAM bindings need to be applied (only when not using folders)
-  iam_target_projects = local.has_folders ? [] : var.monitored_project_ids
+  # Explicitly listed standalone projects always need project-level IAM bindings,
+  # independent of whether folders are also monitored (they live outside the folders).
+  iam_target_projects = var.monitored_project_ids
 
   # Determine roles based on editing permissions
   dataplex_roles = var.enable_datascan_editing ? toset([


### PR DESCRIPTION
## Problem

After an apply, projects listed in `monitored_project_ids` lost their grants — including `RETRO_ACCESS` (`roles/logging.privateLogViewer` for the retro service account) and `INFO_SCHEMA_TIMELINES_ACCESS` (`roles/bigquery.metadataViewer` + `roles/bigquery.resourceViewer`) — whenever any `monitored_folder_ids` were also configured.

## Root cause

All four IAM modules treated folder and project monitoring as mutually exclusive:

```hcl
iam_target_projects = local.has_folders ? [] : var.monitored_project_ids
```

The moment any folder was set, `has_folders` became `true` and `iam_target_projects` collapsed to `[]`, so **every project-level IAM binding for the explicitly listed standalone projects was dropped**. These projects live *outside* the monitored folders, so folder-level bindings never covered them either.

## Fix

- `iam_target_projects` is now always `var.monitored_project_ids`, independent of folder monitoring, in the `bigquery`, `analytics-hub`, `dataplex`, and `dataform` modules.
- Removed the now-redundant `!local.has_folders` guards on the project-level resources that consume it (bigquery privateLogViewer + project custom role/binding; analytics-hub project custom role) — otherwise they would keep no-op'ing.

`has_folders` is still used for folder-level bindings, org custom-role gating, and sink outputs, so no dead locals.

## Validation

- `terraform fmt -recursive -check` → clean
- `terraform validate` → `Success! The configuration is valid.`

⚠️ Before release, run `terraform plan` against an affected deployment to confirm the restored bindings on standalone projects show up as **adds, not destroys**.

## Release

Bumped to **0.4.2** (CHANGELOG, README, docs, pulumi example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)